### PR TITLE
Static uniforms

### DIFF
--- a/vclib/render/include/vclib/bgfx/drawable/drawable_axis.h
+++ b/vclib/render/include/vclib/bgfx/drawable/drawable_axis.h
@@ -24,7 +24,6 @@
 #define VCL_BGFX_DRAWABLE_DRAWABLE_AXIS_H
 
 #include "mesh/mesh_render_buffers.h"
-#include "uniforms/drawable_axis_uniforms.h"
 
 #include <vclib/algorithms/mesh/create.h>
 #include <vclib/meshes/tri_mesh.h>
@@ -56,8 +55,6 @@ class DrawableAxis : public DrawableObject
 
     MeshRenderBuffers<vcl::TriMesh> mArrowBuffers[2]; // 0: cylinder, 1: cone
 
-    mutable DrawableAxisUniforms mUniforms;
-
 public:
     DrawableAxis(double size = 1);
 
@@ -84,7 +81,6 @@ public:
     {
         using std::swap;
         swap(mVisible, other.mVisible);
-        swap(mUniforms, other.mUniforms);
         for (uint i = 0; i < 3; i++) {
             swap(mMatrices[i], other.mMatrices[i]);
         }

--- a/vclib/render/include/vclib/bgfx/drawable/drawable_directional_light.h
+++ b/vclib/render/include/vclib/bgfx/drawable/drawable_directional_light.h
@@ -23,8 +23,6 @@
 #ifndef VCL_BGFX_DRAWABLE_DRAWABLE_DIRECTIONAL_LIGHT_H
 #define VCL_BGFX_DRAWABLE_DRAWABLE_DIRECTIONAL_LIGHT_H
 
-#include "uniforms/drawable_directional_light_uniforms.h"
-
 #include <vclib/render/drawable/drawable_object.h>
 #include <vclib/render/viewer/lights/directional_light.h>
 #include <vclib/space/core/matrix.h>
@@ -46,8 +44,6 @@ class DrawableDirectionalLight : public DrawableObject
     vcl::Color         mColor = vcl::Color::Yellow; // color of the lines
 
     VertexBuffer mVertexPosBuffer;
-
-    DrawableDirectionalLightUniforms mUniform;
 
 public:
     DrawableDirectionalLight();

--- a/vclib/render/include/vclib/bgfx/drawable/drawable_mesh_bgfx.h
+++ b/vclib/render/include/vclib/bgfx/drawable/drawable_mesh_bgfx.h
@@ -50,8 +50,6 @@ private:
 
     mutable MaterialUniforms           mMaterialUniforms;
 
-    Uniform mIdUniform = Uniform("u_meshId", bgfx::UniformType::Vec4);
-
     // TODO: to be removed after shader benchmarks
     SurfaceProgramsType mSurfaceProgramType = SurfaceProgramsType::UBER;
 
@@ -102,7 +100,6 @@ public:
         AbstractDrawableMesh::swap(other);
         MeshType::swap(other);
         swap(mMaterialUniforms, other.mMaterialUniforms);
-        swap(mIdUniform, other.mIdUniform);
         swap(mSurfaceProgramType, other.mSurfaceProgramType);
         swap(mMRB, other.mMRB);
     }
@@ -315,14 +312,12 @@ public:
             model = MeshType::transformMatrix().template cast<float>();
         }
 
-        const std::array<float, 4> idFloat = {
-            std::bit_cast<float>(settings.objectId), 0.0f, 0.0f, 0.0f};
-
         if (mMRS.isSurface(MRI::Surface::VISIBLE)) {
             mMRB.bindVertexBuffers(mMRS);
             mMRB.bindIndexBuffers(mMRS);
-            mIdUniform.bind(&idFloat);
+            DrawableMeshUniforms::setMeshId(settings.objectId);
             DrawableMeshUniforms::setFirstChunkIndex(0);
+            bindUniforms();
 
             bgfx::setState(state);
             bgfx::setTransform(model.data());
@@ -358,7 +353,9 @@ public:
             if (!Context::instance().supportsCompute()) {
                 // 1 px vertices
                 mMRB.bindVertexBuffers(mMRS);
-                mIdUniform.bind(&idFloat);
+
+                DrawableMeshUniforms::setMeshId(settings.objectId);
+                bindUniforms();
 
                 bgfx::setState(state | BGFX_STATE_PT_POINTS);
                 bgfx::setTransform(model.data());
@@ -372,8 +369,8 @@ public:
 
                 // render splats
                 mMRB.bindVertexQuadBuffer();
+                DrawableMeshUniforms::setMeshId(settings.objectId);
                 bindUniforms();
-                mIdUniform.bind(&idFloat);
 
                 bgfx::setState(state);
                 bgfx::setTransform(model.data());

--- a/vclib/render/include/vclib/bgfx/drawable/drawable_mesh_bgfx.h
+++ b/vclib/render/include/vclib/bgfx/drawable/drawable_mesh_bgfx.h
@@ -50,7 +50,6 @@ private:
 
     mutable DrawableMeshUniforms       mMeshUniforms;
     mutable MaterialUniforms           mMaterialUniforms;
-    mutable MeshRenderSettingsUniforms mMeshRenderSettingsUniforms;
 
     Uniform mIdUniform = Uniform("u_meshId", bgfx::UniformType::Vec4);
 
@@ -85,7 +84,6 @@ public:
         if constexpr (HasName<MeshType>) {
             AbstractDrawableMesh::name() = drawableMesh.name();
         }
-        mMeshRenderSettingsUniforms.updateSettings(mMRS);
         updateBuffers();
     }
 
@@ -106,7 +104,6 @@ public:
         MeshType::swap(other);
         swap(mMeshUniforms, other.mMeshUniforms);
         swap(mMaterialUniforms, other.mMaterialUniforms);
-        swap(mMeshRenderSettingsUniforms, other.mMeshRenderSettingsUniforms);
         swap(mIdUniform, other.mIdUniform);
         swap(mSurfaceProgramType, other.mSurfaceProgramType);
         swap(mMRB, other.mMRB);
@@ -152,7 +149,6 @@ public:
     void setRenderSettings(const MeshRenderSettings& rs) override
     {
         AbstractDrawableMesh::setRenderSettings(rs);
-        mMeshRenderSettingsUniforms.updateSettings(rs);
         mMRB.updateEdgeSettings(rs);
         mMRB.updateWireframeSettings(rs);
     }
@@ -225,6 +221,7 @@ public:
         }
 
         mMeshUniforms.update(*this);
+        MeshRenderSettingsUniforms::set(mMRS);
 
         if (mMRS.isSurface(MRI::Surface::VISIBLE)) {
             for (uint i = 0; i < mMRB.triangleChunksNumber(); ++i) {
@@ -400,12 +397,6 @@ public:
         return std::make_shared<DrawableMeshBGFX>(std::move(*this));
     }
 
-    void setVisibility(bool vis) override
-    {
-        AbstractDrawableMesh::setVisibility(vis);
-        mMeshRenderSettingsUniforms.updateSettings(mMRS);
-    }
-
     std::string& name() override { return MeshType::name(); }
 
     const std::string& name() const override { return MeshType::name(); }
@@ -413,8 +404,8 @@ public:
 protected:
     void bindUniforms() const
     {
+        MeshRenderSettingsUniforms::bind();
         mMeshUniforms.bind();
-        mMeshRenderSettingsUniforms.bind();
     }
 
     /**

--- a/vclib/render/include/vclib/bgfx/drawable/drawable_mesh_bgfx.h
+++ b/vclib/render/include/vclib/bgfx/drawable/drawable_mesh_bgfx.h
@@ -48,7 +48,6 @@ public:
 private:
     using MRI = MeshRenderInfo;
 
-    mutable DrawableMeshUniforms       mMeshUniforms;
     mutable MaterialUniforms           mMaterialUniforms;
 
     Uniform mIdUniform = Uniform("u_meshId", bgfx::UniformType::Vec4);
@@ -102,7 +101,6 @@ public:
         using std::swap;
         AbstractDrawableMesh::swap(other);
         MeshType::swap(other);
-        swap(mMeshUniforms, other.mMeshUniforms);
         swap(mMaterialUniforms, other.mMaterialUniforms);
         swap(mIdUniform, other.mIdUniform);
         swap(mSurfaceProgramType, other.mSurfaceProgramType);
@@ -220,7 +218,7 @@ public:
             model = MeshType::transformMatrix().template cast<float>();
         }
 
-        mMeshUniforms.update(*this);
+        DrawableMeshUniforms::setColor(*this);
         MeshRenderSettingsUniforms::set(mMRS);
 
         if (mMRS.isSurface(MRI::Surface::VISIBLE)) {
@@ -232,7 +230,7 @@ public:
                 mMRB.bindVertexBuffers(mMRS);
                 mMRB.bindIndexBuffers(mMRS, i);
 
-                mMeshUniforms.updateFirstChunkIndex(
+                DrawableMeshUniforms::setFirstChunkIndex(
                     mMRB.triangleChunk(i).startIndex);
 
                 bindUniforms();
@@ -324,7 +322,7 @@ public:
             mMRB.bindVertexBuffers(mMRS);
             mMRB.bindIndexBuffers(mMRS);
             mIdUniform.bind(&idFloat);
-            mMeshUniforms.updateFirstChunkIndex(0);
+            DrawableMeshUniforms::setFirstChunkIndex(0);
 
             bgfx::setState(state);
             bgfx::setTransform(model.data());
@@ -405,7 +403,7 @@ protected:
     void bindUniforms() const
     {
         MeshRenderSettingsUniforms::bind();
-        mMeshUniforms.bind();
+        DrawableMeshUniforms::bind();
     }
 
     /**

--- a/vclib/render/include/vclib/bgfx/drawable/drawable_trackball.h
+++ b/vclib/render/include/vclib/bgfx/drawable/drawable_trackball.h
@@ -23,8 +23,6 @@
 #ifndef VCL_BGFX_DRAWABLE_DRAWABLE_TRACKBALL_H
 #define VCL_BGFX_DRAWABLE_DRAWABLE_TRACKBALL_H
 
-#include "uniforms/drawable_trackball_uniforms.h"
-
 #include <vclib/algorithms/core.h>
 #include <vclib/bgfx/buffers.h>
 #include <vclib/render/drawable/drawable_object.h>
@@ -38,9 +36,8 @@ class DrawableTrackBall : public DrawableObject
     VertexBuffer mVertexPosColorBuffer;
     IndexBuffer  mEdgeIndexBuffer;
 
-    DrawableTrackballUniforms mUniforms;
-
-    vcl::Matrix44f mTransform = vcl::Matrix44f::Identity();
+    vcl::Matrix44f mTransform  = vcl::Matrix44f::Identity();
+    bool           mIsDragging = false;
 
 public:
     DrawableTrackBall();

--- a/vclib/render/include/vclib/bgfx/drawable/mesh/mesh_render_buffers.h
+++ b/vclib/render/include/vclib/bgfx/drawable/mesh/mesh_render_buffers.h
@@ -79,7 +79,7 @@ class MeshRenderBuffers : public MeshRenderData<MeshRenderBuffers<Mesh>>
     // for each texture path of each material, store its texture
     std::map<std::string, Texture> mMaterialTextures;
 
-    std::array<Uniform, N_TEXTURE_TYPES> mTextureSamplerUniforms;
+    static inline std::array<Uniform, N_TEXTURE_TYPES> sTextureSamplerUniforms;
 
 public:
     MeshRenderBuffers() = default;
@@ -123,7 +123,6 @@ public:
         swap(mEdgeLines, other.mEdgeLines);
         swap(mWireframeLines, other.mWireframeLines);
         swap(mMaterialTextures, other.mMaterialTextures);
-        swap(mTextureSamplerUniforms, other.mTextureSamplerUniforms);
     }
 
     friend void swap(MeshRenderBuffers& a, MeshRenderBuffers& b) { a.swap(b); }
@@ -235,7 +234,7 @@ public:
                         uint flags = Texture::samplerFlagsFromTexture(td);
                         tex.bind(
                             VCL_MRB_TEXTURE0 + j,
-                            mTextureSamplerUniforms[j].handle(),
+                            sTextureSamplerUniforms[j].handle(),
                             flags);
                     }
                 }
@@ -762,12 +761,16 @@ private:
         // otherwise, already computed buffers should do the job
     }
 
-    void createTextureSamplerUniforms()
+    static void createTextureSamplerUniforms()
     {
-        for (uint i = 0; i < mTextureSamplerUniforms.size(); ++i) {
-            mTextureSamplerUniforms[i] = Uniform(
-                Material::TEXTURE_TYPE_NAMES[i].c_str(),
-                bgfx::UniformType::Sampler);
+        // lazy initialization
+        // to avoid creating uniforms before bgfx is initialized
+        if (!sTextureSamplerUniforms[0].isValid()) {
+            for (uint i = 0; i < sTextureSamplerUniforms.size(); ++i) {
+                sTextureSamplerUniforms[i] = Uniform(
+                    Material::TEXTURE_TYPE_NAMES[i].c_str(),
+                    bgfx::UniformType::Sampler);
+            }
         }
     }
 };

--- a/vclib/render/include/vclib/bgfx/drawable/uniforms/directional_light_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/drawable/uniforms/directional_light_uniforms.h
@@ -31,11 +31,14 @@
 namespace vcl {
 
 /**
- * @brief The DirectionalLightUniforms class manages the uniforms which describe
- * a directional light that can be used by bgfx shaders.
+ * @brief The DirectionalLightUniforms class is responsible for managing the
+ * uniforms which describe a directional light that can be used by bgfx shaders.
+ *
+ * It provides a static interface to set the uniform data based on the current
+ * directional light data and to bind the uniforms to the shader programs.
  *
  * The uniforms of this class can be used by including the shader header
- * "uniforms/uniforms/directional_light_uniforms.sh" in the shader.
+ * <vclib/bgfx/drawable/uniforms/directional_light_uniforms.sh> in the shader.
  *
  * The uniforms are:
  * - u_lightDirPack (vec4): the light direction packed in a vec4
@@ -47,38 +50,46 @@ namespace vcl {
  */
 class DirectionalLightUniforms
 {
-    float mDir[4] = {0.0, 0.0, 1.0, 0.0}; // just first 3 components are used
-    float mCol[4] = {1.0, 1.0, 1.0, 1.0}; // just first 3 components are used
+    // just first 3 components are used
+    inline static std::array<float, 4> sDir = {0.0, 0.0, 1.0, 0.0};
 
-    Uniform mLightDirUniform =
-        Uniform("u_lightDirPack", bgfx::UniformType::Vec4);
-    Uniform mLightColorUniform =
-        Uniform("u_lightColorPack", bgfx::UniformType::Vec4);
+    // just first 3 components are used
+    inline static std::array<float, 4> sCol = {1.0, 1.0, 1.0, 1.0};
+
+    inline static Uniform sLightDirUniform;
+    inline static Uniform sLightColorUniform;
 
 public:
-    DirectionalLightUniforms() {}
+    DirectionalLightUniforms() = delete;
 
     /**
-     * @brief updateLight
+     * @brief setLight
      * @param light
      */
     template<typename S>
-    void updateLight(const vcl::DirectionalLight<S>& light)
+    static void setLight(const vcl::DirectionalLight<S>& light)
     {
-        mDir[0] = light.direction().x();
-        mDir[1] = light.direction().y();
-        mDir[2] = light.direction().z();
+        sDir[0] = light.direction().x();
+        sDir[1] = light.direction().y();
+        sDir[2] = light.direction().z();
 
-        mCol[0] = light.color().redF();
-        mCol[1] = light.color().greenF();
-        mCol[2] = light.color().blueF();
+        sCol[0] = light.color().redF();
+        sCol[1] = light.color().greenF();
+        sCol[2] = light.color().blueF();
         // light color alpha is not used
     }
 
-    void bind() const
+    static void bind()
     {
-        mLightDirUniform.bind(mDir);
-        mLightColorUniform.bind(mCol);
+        // lazy initialization
+        // to avoid creating uniforms before bgfx is initialized
+        if (!sLightDirUniform.isValid())
+            sLightDirUniform = Uniform("u_lightDirPack", bgfx::UniformType::Vec4);
+        if (!sLightColorUniform.isValid())
+            sLightColorUniform =
+                Uniform("u_lightColorPack", bgfx::UniformType::Vec4);
+        sLightDirUniform.bind(sDir.data());
+        sLightColorUniform.bind(sCol.data());
     }
 };
 

--- a/vclib/render/include/vclib/bgfx/drawable/uniforms/drawable_axis_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/drawable/uniforms/drawable_axis_uniforms.h
@@ -28,24 +28,38 @@
 
 namespace vcl {
 
+/**
+ * @brief The DrawableAxisUniforms class is responsible for managing the shader
+ * uniforms related to a drawable axis.
+ *
+ * It provides an interface to set the uniform data based on the current axis
+ * data and to bind the uniforms to the shader programs.
+ */
 class DrawableAxisUniforms
 {
-    float mAxisColor[4] = {1.0, 0.0, 0.0, 1.0};
+    inline static std::array<float, 4> sAxisColor = {1.0, 0.0, 0.0, 1.0};
 
-    Uniform mAxisColorUniform = Uniform("u_axisColor", bgfx::UniformType::Vec4);
+    inline static Uniform sAxisColorUniform;
 
 public:
-    DrawableAxisUniforms() = default;
+    DrawableAxisUniforms() = delete;
 
-    void setColor(const vcl::Color& color)
+    static void setColor(const vcl::Color& color)
     {
-        mAxisColor[0] = color.redF();
-        mAxisColor[1] = color.greenF();
-        mAxisColor[2] = color.blueF();
-        mAxisColor[3] = color.alphaF();
+        sAxisColor[0] = color.redF();
+        sAxisColor[1] = color.greenF();
+        sAxisColor[2] = color.blueF();
+        sAxisColor[3] = color.alphaF();
     }
 
-    void bind() const { mAxisColorUniform.bind(mAxisColor); }
+    static void bind()
+    {
+        // lazy initialization
+        // to avoid creating uniforms before bgfx is initialized
+        if (!sAxisColorUniform.isValid())
+            sAxisColorUniform = Uniform("u_axisColor", bgfx::UniformType::Vec4);
+        sAxisColorUniform.bind(sAxisColor.data());
+    }
 };
 
 } // namespace vcl

--- a/vclib/render/include/vclib/bgfx/drawable/uniforms/drawable_directional_light_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/drawable/uniforms/drawable_directional_light_uniforms.h
@@ -30,23 +30,30 @@ namespace vcl {
 
 class DrawableDirectionalLightUniforms
 {
-    float mLightColor[4] = {1.0, 1.0, 0.0, 1.0};
+    inline static std::array<float, 4> sLightColor = {1.0, 1.0, 0.0, 1.0};
 
-    Uniform mLightColorUniform =
-        Uniform("u_drawableDirectionalLightColor", bgfx::UniformType::Vec4);
+    inline static Uniform sLightColorUniform;
 
 public:
-    DrawableDirectionalLightUniforms() = default;
+    DrawableDirectionalLightUniforms() = delete;
 
-    void setColor(const vcl::Color& color)
+    static void setColor(const vcl::Color& color)
     {
-        mLightColor[0] = color.redF();
-        mLightColor[1] = color.greenF();
-        mLightColor[2] = color.blueF();
-        mLightColor[3] = color.alphaF();
+        sLightColor[0] = color.redF();
+        sLightColor[1] = color.greenF();
+        sLightColor[2] = color.blueF();
+        sLightColor[3] = color.alphaF();
     }
 
-    void bind() const { mLightColorUniform.bind(mLightColor); }
+    static void bind()
+    {
+        // lazy initialization
+        // to avoid creating uniforms before bgfx is initialized
+        if (!sLightColorUniform.isValid())
+            sLightColorUniform = Uniform(
+                "u_drawableDirectionalLightColor", bgfx::UniformType::Vec4);
+        sLightColorUniform.bind(sLightColor.data());
+    }
 };
 
 } // namespace vcl

--- a/vclib/render/include/vclib/bgfx/drawable/uniforms/drawable_mesh_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/drawable/uniforms/drawable_mesh_uniforms.h
@@ -39,7 +39,8 @@ class DrawableMeshUniforms
 {
     inline static std::array<float, 4> sMeshColor = {0.5, 0.5, 0.5, 1.0};
 
-    // sMeshData[0] -> as uint, first chunk primitive id drawn
+    // sMeshData[0] -> as uint, mesh id
+    // sMeshData[1] -> as uint, first chunk primitive id drawn
     inline static std::array<float, 4> sMeshData = {0.0, 0.0, 0.0, 0.0};
 
     inline static Uniform sMeshColorUniform;
@@ -59,9 +60,14 @@ public:
         }
     }
 
+    static void setMeshId(uint meshId)
+    {
+        sMeshData[0] = std::bit_cast<float>(meshId);
+    }
+
     static void setFirstChunkIndex(uint firstChunkIndex)
     {
-        sMeshData[0] = std::bit_cast<float>(firstChunkIndex);
+        sMeshData[1] = std::bit_cast<float>(firstChunkIndex);
     }
 
     static void bind()

--- a/vclib/render/include/vclib/bgfx/drawable/uniforms/drawable_mesh_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/drawable/uniforms/drawable_mesh_uniforms.h
@@ -28,44 +28,52 @@
 
 namespace vcl {
 
+/**
+ * @brief The DrawableMeshUniforms class is responsible for managing the
+ * shader uniforms related to a drawable mesh.
+ *
+ * It provides a static interface to set the uniform data based on the
+ * current mesh data and to bind the uniforms to the shader programs.
+ */
 class DrawableMeshUniforms
 {
-    float mMeshColor[4] = {0.5, 0.5, 0.5, 1.0};
+    inline static std::array<float, 4> sMeshColor = {0.5, 0.5, 0.5, 1.0};
 
-    float mMeshData[4] = {
-        0.0, // as uint: first chunk primitive id drawn
-        0.0,
-        0.0,
-        0.0};
+    // sMeshData[0] -> as uint, first chunk primitive id drawn
+    inline static std::array<float, 4> sMeshData = {0.0, 0.0, 0.0, 0.0};
 
-    Uniform mMeshColorUniform = Uniform("u_meshColor", bgfx::UniformType::Vec4);
-    Uniform mMeshDataUniform  = Uniform("u_meshData", bgfx::UniformType::Vec4);
+    inline static Uniform sMeshColorUniform;
+    inline static Uniform sMeshDataUniform;
 
 public:
-    DrawableMeshUniforms() = default;
-
-    const float* currentMeshColor() const { return mMeshColor; }
+    DrawableMeshUniforms() = delete;
 
     template<MeshConcept MeshType>
-    void update(const MeshType& m)
+    static void setColor(const MeshType& m)
     {
         if constexpr (HasColor<MeshType>) {
-            mMeshColor[0] = m.color().redF();
-            mMeshColor[1] = m.color().greenF();
-            mMeshColor[2] = m.color().blueF();
-            mMeshColor[3] = m.color().alphaF();
+            sMeshColor[0] = m.color().redF();
+            sMeshColor[1] = m.color().greenF();
+            sMeshColor[2] = m.color().blueF();
+            sMeshColor[3] = m.color().alphaF();
         }
     }
 
-    void updateFirstChunkIndex(uint firstChunkIndex)
+    static void setFirstChunkIndex(uint firstChunkIndex)
     {
-        mMeshData[0] = std::bit_cast<float>(firstChunkIndex);
+        sMeshData[0] = std::bit_cast<float>(firstChunkIndex);
     }
 
-    void bind() const
+    static void bind()
     {
-        mMeshColorUniform.bind(mMeshColor);
-        mMeshDataUniform.bind(mMeshData);
+        // lazy initialization
+        // to avoid creating uniforms before bgfx is initialized
+        if (!sMeshColorUniform.isValid())
+            sMeshColorUniform = Uniform("u_meshColor", bgfx::UniformType::Vec4);
+        if (!sMeshDataUniform.isValid())
+            sMeshDataUniform = Uniform("u_meshData", bgfx::UniformType::Vec4);
+        sMeshColorUniform.bind(sMeshColor.data());
+        sMeshDataUniform.bind(sMeshData.data());
     }
 };
 

--- a/vclib/render/include/vclib/bgfx/drawable/uniforms/drawable_trackball_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/drawable/uniforms/drawable_trackball_uniforms.h
@@ -28,31 +28,40 @@
 
 namespace vcl {
 
+/**
+ * @brief The DrawableTrackballUniforms class is responsible for managing the
+ * shader uniforms related to a drawable trackball.
+ *
+ * It provides a static interface to set the uniform data based on the
+ * current dragging status and to bind the uniforms to the shader programs.
+ */
 class DrawableTrackballUniforms
 {
     static constexpr float DRAGGING_ALPHA     = 0.9f;
     static constexpr float NOT_DRAGGING_ALPHA = 0.5f;
 
     // the only component is alpha
-    std::array<float, 4> mTrackBallSettings;
+    inline static std::array<float, 4> sTrackBallSettings =
+        {NOT_DRAGGING_ALPHA, 0, 0, 0};
 
-    Uniform mTrackballSettingsUniform =
-        Uniform("u_trackballSettingsPack", bgfx::UniformType::Vec4);
+    inline static Uniform sTrackballSettingsUniform;
 
 public:
-    DrawableTrackballUniforms()
+    DrawableTrackballUniforms() = delete;
+
+    static void setDragging(bool dragging)
     {
-        mTrackBallSettings[0] = NOT_DRAGGING_ALPHA; // default: not dragging
+        sTrackBallSettings[0] = dragging ? DRAGGING_ALPHA : NOT_DRAGGING_ALPHA;
     }
 
-    void setDragging(bool dragging)
+    static void bind()
     {
-        mTrackBallSettings[0] = dragging ? DRAGGING_ALPHA : NOT_DRAGGING_ALPHA;
-    }
-
-    void bind() const
-    {
-        mTrackballSettingsUniform.bind(mTrackBallSettings.data());
+        // lazy initialization
+        // to avoid creating uniforms before bgfx is initialized
+        if (!sTrackballSettingsUniform.isValid())
+            sTrackballSettingsUniform =
+                Uniform("u_trackballSettingsPack", bgfx::UniformType::Vec4);
+        sTrackballSettingsUniform.bind(sTrackBallSettings.data());
     }
 };
 

--- a/vclib/render/include/vclib/bgfx/drawable/uniforms/mesh_render_settings_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/drawable/uniforms/mesh_render_settings_uniforms.h
@@ -30,37 +30,41 @@
 
 namespace vcl {
 
+/**
+ * @brief The MeshRenderSettingsUniforms class is responsible for managing the
+ * shader uniforms related to mesh render settings.
+ *
+ * It provides a static interface to set the uniform data based on the
+ * current mesh render settings and to bind the uniforms to the shader programs.
+ */
 class MeshRenderSettingsUniforms
 {
-    // mDrawPack[0] -> draw mode0
-    // mDrawPack[1] -> draw mode1
-    // mDrawPack[2] -> unused
-    // mDrawPack[3] -> unused
-    float mDrawPack[4] = {0.0, 0.0, 0.0, 0.0};
+    // sDrawPack[0] -> draw mode0
+    // sDrawPack[1] -> draw mode1
+    // sDrawPack[2] -> unused
+    // sDrawPack[3] -> unused
+    inline static std::array<float, 4> sDrawPack = {0.0, 0.0, 0.0, 0.0};
 
-    // mWidthPack[0] -> point width
-    // mWidthPack[1] -> wireframe width
-    // mWidthPack[2] -> edge width
-    // mWidthPack[3] -> unused
-    float mWidthPack[4] = {0.0, 0.0, 0.0, 0.0};
+    // sWidthPack[0] -> point width
+    // sWidthPack[1] -> wireframe width
+    // sWidthPack[2] -> edge width
+    // sWidthPack[3] -> unused
+    inline static std::array<float, 4> sWidthPack = {0.0, 0.0, 0.0, 0.0};
 
-    // mColorPack[0] -> point user color
-    // mColorPack[1] -> surface user color
-    // mColorPack[2] -> wireframe user color
-    // mColorPack[3] -> edge user color
-    float mColorPack[4] = {0.0, 0.0, 0.0, 0.0};
+    // sColorPack[0] -> point user color
+    // sColorPack[1] -> surface user color
+    // sColorPack[2] -> wireframe user color
+    // sColorPack[3] -> edge user color
+    inline static std::array<float, 4> sColorPack = {0.0, 0.0, 0.0, 0.0};
 
-    Uniform mDrawModeUniform =
-        Uniform("u_mrsDrawPack", bgfx::UniformType::Vec4);
-
-    Uniform mWidthUniform = Uniform("u_mrsWidthPack", bgfx::UniformType::Vec4);
-
-    Uniform mColorUniform = Uniform("u_mrsColorPack", bgfx::UniformType::Vec4);
+    inline static Uniform sDrawModeUniform;
+    inline static Uniform sWidthUniform;
+    inline static Uniform sColorUniform;
 
 public:
-    MeshRenderSettingsUniforms() {}
+    MeshRenderSettingsUniforms() = delete;
 
-    void updateSettings(const vcl::MeshRenderSettings& settings)
+    static void set(const vcl::MeshRenderSettings& settings)
     {
         auto mri = settings.drawMode();
         uint d0  = mri.points().underlying();
@@ -68,26 +72,35 @@ public:
         uint d1 = mri.wireframe().underlying();
         d1 |= mri.edges().underlying() << 16;
 
-        mDrawPack[0] = std::bit_cast<float>(d0);
-        mDrawPack[1] = std::bit_cast<float>(d1);
+        sDrawPack[0] = std::bit_cast<float>(d0);
+        sDrawPack[1] = std::bit_cast<float>(d1);
 
-        mWidthPack[0] = settings.pointWidth();
-        mWidthPack[1] = settings.wireframeWidth();
-        mWidthPack[2] = settings.edgesWidth();
+        sWidthPack[0] = settings.pointWidth();
+        sWidthPack[1] = settings.wireframeWidth();
+        sWidthPack[2] = settings.edgesWidth();
 
-        mColorPack[0] = std::bit_cast<float>(settings.pointUserColor().abgr());
-        mColorPack[1] =
+        sColorPack[0] = std::bit_cast<float>(settings.pointUserColor().abgr());
+        sColorPack[1] =
             std::bit_cast<float>(settings.surfaceUserColor().abgr());
-        mColorPack[2] =
+        sColorPack[2] =
             std::bit_cast<float>(settings.wireframeUserColor().abgr());
-        mColorPack[3] = std::bit_cast<float>(settings.edgesUserColor().abgr());
+        sColorPack[3] = std::bit_cast<float>(settings.edgesUserColor().abgr());
     }
 
-    void bind() const
+    static void bind()
     {
-        mDrawModeUniform.bind(mDrawPack);
-        mWidthUniform.bind(mWidthPack);
-        mColorUniform.bind(mColorPack);
+        // lazy initialization
+        // to avoid creating uniforms before bgfx is initialized
+        if (!sDrawModeUniform.isValid())
+            sDrawModeUniform =
+                Uniform("u_mrsDrawPack", bgfx::UniformType::Vec4);
+        if (!sWidthUniform.isValid())
+            sWidthUniform = Uniform("u_mrsWidthPack", bgfx::UniformType::Vec4);
+        if (!sColorUniform.isValid())
+            sColorUniform = Uniform("u_mrsColorPack", bgfx::UniformType::Vec4);
+        sDrawModeUniform.bind(sDrawPack.data());
+        sWidthUniform.bind(sWidthPack.data());
+        sColorUniform.bind(sColorPack.data());
     }
 };
 

--- a/vclib/render/include/vclib/bgfx/drawers/viewer_drawer_bgfx.h
+++ b/vclib/render/include/vclib/bgfx/drawers/viewer_drawer_bgfx.h
@@ -36,8 +36,6 @@ class ViewerDrawerBGFX : public AbstractViewerDrawer<ViewProjEventDrawer>
 {
     using ParentViewer = AbstractViewerDrawer<ViewProjEventDrawer>;
 
-    DirectionalLightUniforms mDirectionalLightUniforms;
-
     // flags
     bool mStatsEnabled = false;
 
@@ -47,7 +45,6 @@ public:
     ViewerDrawerBGFX(uint width = 1024, uint height = 768) :
             ParentViewer(width, height)
     {
-        mDirectionalLightUniforms.updateLight(ParentViewer::light());
     }
 
     ViewerDrawerBGFX(
@@ -75,8 +72,8 @@ public:
 
         setViewTransform(viewId);
 
-        mDirectionalLightUniforms.updateLight(ParentViewer::light());
-        mDirectionalLightUniforms.bind();
+        DirectionalLightUniforms::setLight(ParentViewer::light());
+        DirectionalLightUniforms::bind();
 
         ParentViewer::drawableObjectVector().draw(settings);
     }

--- a/vclib/render/include/vclib/bgfx/primitives/lines.h
+++ b/vclib/render/include/vclib/bgfx/primitives/lines.h
@@ -91,9 +91,10 @@ private:
 
     ImplementationType mType = ImplementationType::COUNT;
 
-    Uniform mSettingUH = Uniform("u_settings", bgfx::UniformType::Vec4);
     std::variant<detail::PrimitiveLines, detail::CPUGeneratedLines>
         mLinesImplementation;
+
+    static inline Uniform sSettingUH;
 
 public:
     /**
@@ -502,12 +503,17 @@ private:
 
     void bindSettingsUniform() const
     {
+        // lazy initialization
+        // to avoid creating uniforms before bgfx is initialized
+        if (!sSettingUH.isValid())
+            sSettingUH = Uniform("u_settings", bgfx::UniformType::Vec4);
+
         float data[] = {
             mThickness,
             static_cast<float>(mColorToUse),
             std::bit_cast<float>(mGeneralColor.abgr()),
             static_cast<float>(mShadingPerVertex)};
-        mSettingUH.bind(data);
+        sSettingUH.bind(data);
     }
 };
 

--- a/vclib/render/include/vclib/bgfx/uniform.h
+++ b/vclib/render/include/vclib/bgfx/uniform.h
@@ -114,6 +114,13 @@ public:
      */
     friend void swap(Uniform& a, Uniform& b) { a.swap(b); }
 
+     /**
+     * @brief Checks if the Uniform is valid (i.e., if it has a valid
+     * bgfx::UniformHandle).
+     * @return true if the Uniform is valid, false otherwise.
+     */
+    bool isValid() const { return bgfx::isValid(mUniformHandle); }
+
     /**
      * @brief Returns the underlying bgfx::UniformHandle.
      * @return The handle to the uniform.

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/edges_id/fs_edges_id.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/edges_id/fs_edges_id.sc
@@ -22,12 +22,12 @@
 
 #include <vclib/bgfx/shaders_common.sh>
 
-uniform vec4 u_meshId;
+#include <vclib/bgfx/drawable/uniforms/drawable_mesh_uniforms.sh>
 
 void main()
 {
     /***** render ID to color ******/
-    vec4 color = uintABGRToVec4Color(floatBitsToUint(u_meshId.r));
+    vec4 color = uintABGRToVec4Color(u_meshId);
 
     gl_FragColor = color;
 }

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/points_id/fs_points_id.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/points_id/fs_points_id.sc
@@ -22,12 +22,12 @@
 
 #include <vclib/bgfx/shaders_common.sh>
 
-uniform vec4 u_meshId;
+#include <vclib/bgfx/drawable/uniforms/drawable_mesh_uniforms.sh>
 
 void main()
 {
     /***** render ID to color ******/
-    vec4 color = uintABGRToVec4Color(floatBitsToUint(u_meshId.r));
+    vec4 color = uintABGRToVec4Color(u_meshId);
 
     gl_FragColor = color;
 }

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/points_instance_id/fs_points_instance_id.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/points_instance_id/fs_points_instance_id.sc
@@ -24,8 +24,6 @@ $input v_texcoord1
 
 #include <vclib/bgfx/drawable/drawable_mesh/uniforms.sh>
 
-uniform vec4 u_meshId;
-
 void main()
 {
     // circle mode (if outside of the circle, discard)
@@ -36,7 +34,7 @@ void main()
     }
     
     /***** render ID to color ******/
-    vec4 color = uintABGRToVec4Color(floatBitsToUint(u_meshId.r));
+    vec4 color = uintABGRToVec4Color(u_meshId);
 
     gl_FragColor = color;
 }

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface_id/fs_surface_id.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface_id/fs_surface_id.sc
@@ -22,12 +22,12 @@
 
 #include <vclib/bgfx/shaders_common.sh>
 
-uniform vec4 u_meshId;
+#include <vclib/bgfx/drawable/uniforms/drawable_mesh_uniforms.sh>
 
 void main()
 {
     /***** render ID to color ******/
-    vec4 color = uintABGRToVec4Color(floatBitsToUint(u_meshId.r));
+    vec4 color = uintABGRToVec4Color(u_meshId);
 
     gl_FragColor = color;
 }

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/wireframe_id/fs_wireframe_id.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/wireframe_id/fs_wireframe_id.sc
@@ -22,12 +22,12 @@
 
 #include <vclib/bgfx/shaders_common.sh>
 
-uniform vec4 u_meshId;
+#include <vclib/bgfx/drawable/uniforms/drawable_mesh_uniforms.sh>
 
 void main()
 {
     /***** render ID to color ******/
-    vec4 color = uintABGRToVec4Color(floatBitsToUint(u_meshId.r));
+    vec4 color = uintABGRToVec4Color(u_meshId);
 
     gl_FragColor = color;
 }

--- a/vclib/render/shaders/vclib/bgfx/drawable/uniforms/drawable_mesh_uniforms.sh
+++ b/vclib/render/shaders/vclib/bgfx/drawable/uniforms/drawable_mesh_uniforms.sh
@@ -24,8 +24,9 @@
 #define VCL_EXT_BGFX_UNIFORMS_DRAWABLE_MESH_UNIFORMS_SH
 
 uniform vec4 u_meshColor;
-uniform vec4 u_meshData; // x: first chunk index
+uniform vec4 u_meshData; // x: meshId; y: first chunk index
 
-#define u_firstChunkPrimitiveID floatBitsToUint(u_meshData.x)
+#define u_meshId floatBitsToUint(u_meshData.x)
+#define u_firstChunkPrimitiveID floatBitsToUint(u_meshData.y)
 
 #endif // VCL_EXT_BGFX_UNIFORMS_DRAWABLE_MESH_UNIFORMS_SH

--- a/vclib/render/src/vclib/bgfx/drawable/drawable_axis.cpp
+++ b/vclib/render/src/vclib/bgfx/drawable/drawable_axis.cpp
@@ -22,6 +22,8 @@
 
 #include <vclib/bgfx/drawable/drawable_axis.h>
 
+#include <vclib/bgfx/drawable/uniforms/drawable_axis_uniforms.h>
+
 #include <vclib/algorithms/mesh/create.h>
 
 namespace vcl {
@@ -51,10 +53,10 @@ void DrawableAxis::draw(const DrawObjectSettings& settings) const
         for (uint i = 0; i < 3; i++) {
             for (uint j = 0; j < 2; j++) {
                 if (j == 0) // cylinders
-                    mUniforms.setColor(AXIS_COLORS[i]);
+                    DrawableAxisUniforms::setColor(AXIS_COLORS[i]);
                 else // rest (cone, spheres...)
-                    mUniforms.setColor(vcl::Color::White);
-                mUniforms.bind();
+                    DrawableAxisUniforms::setColor(vcl::Color::White);
+                DrawableAxisUniforms::bind();
 
                 mArrowBuffers[j].bindVertexBuffers(MeshRenderSettings());
                 mArrowBuffers[j].bindIndexBuffers(MeshRenderSettings());

--- a/vclib/render/src/vclib/bgfx/drawable/drawable_directional_light.cpp
+++ b/vclib/render/src/vclib/bgfx/drawable/drawable_directional_light.cpp
@@ -22,6 +22,8 @@
 
 #include <vclib/bgfx/drawable/drawable_directional_light.h>
 
+#include <vclib/bgfx/drawable/uniforms/drawable_directional_light_uniforms.h>
+
 #include <vclib/algorithms/core.h>
 
 namespace vcl {
@@ -55,7 +57,6 @@ DrawableDirectionalLight::DrawableDirectionalLight()
     }
 
     createVertexBuffer();
-    setLinesColor(mColor);
 }
 
 DrawableDirectionalLight::DrawableDirectionalLight(
@@ -65,7 +66,6 @@ DrawableDirectionalLight::DrawableDirectionalLight(
         mColor(other.mColor)
 {
     createVertexBuffer();
-    mUniform.setColor(mColor);
 }
 
 DrawableDirectionalLight::DrawableDirectionalLight(
@@ -91,7 +91,6 @@ void DrawableDirectionalLight::swap(DrawableDirectionalLight& other)
     swap(mVisible, other.mVisible);
     mVertices.swap(other.mVertices);
     swap(mColor, other.mColor);
-    swap(mUniform, other.mUniform);
     swap(mTransform, other.mTransform);
     swap(mVertexPosBuffer, other.mVertexPosBuffer);
 }
@@ -104,7 +103,6 @@ void DrawableDirectionalLight::updateRotation(const Matrix44f& rot)
 void DrawableDirectionalLight::setLinesColor(const Color& c)
 {
     mColor = c;
-    mUniform.setColor(mColor);
 }
 
 void DrawableDirectionalLight::draw(const DrawObjectSettings& settings) const
@@ -120,7 +118,8 @@ void DrawableDirectionalLight::draw(const DrawObjectSettings& settings) const
 
         bgfx::setTransform(mTransform.data());
 
-        mUniform.bind();
+        DrawableDirectionalLightUniforms::setColor(mColor);
+        DrawableDirectionalLightUniforms::bind();
 
         mVertexPosBuffer.bind(0);
 

--- a/vclib/render/src/vclib/bgfx/drawable/drawable_trackball.cpp
+++ b/vclib/render/src/vclib/bgfx/drawable/drawable_trackball.cpp
@@ -128,6 +128,7 @@ void DrawableTrackBall::swap(DrawableTrackBall& other)
     swap(mVertexPosColorBuffer, other.mVertexPosColorBuffer);
     swap(mEdgeIndexBuffer, other.mEdgeIndexBuffer);
     swap(mTransform, other.mTransform);
+    swap(mIsDragging, other.mIsDragging);
 }
 
 /**

--- a/vclib/render/src/vclib/bgfx/drawable/drawable_trackball.cpp
+++ b/vclib/render/src/vclib/bgfx/drawable/drawable_trackball.cpp
@@ -22,6 +22,8 @@
 
 #include <vclib/bgfx/drawable/drawable_trackball.h>
 
+#include <vclib/bgfx/drawable/uniforms/drawable_trackball_uniforms.h>
+
 #include <vclib/algorithms/core/create.h>
 #include <vclib/bgfx/context.h>
 
@@ -125,7 +127,6 @@ void DrawableTrackBall::swap(DrawableTrackBall& other)
     swap(mVisible, other.mVisible);
     swap(mVertexPosColorBuffer, other.mVertexPosColorBuffer);
     swap(mEdgeIndexBuffer, other.mEdgeIndexBuffer);
-    swap(mUniforms, other.mUniforms);
     swap(mTransform, other.mTransform);
 }
 
@@ -136,7 +137,7 @@ void DrawableTrackBall::swap(DrawableTrackBall& other)
  */
 void DrawableTrackBall::updateDragging(bool isDragging)
 {
-    mUniforms.setDragging(isDragging);
+    mIsDragging = isDragging;
 }
 
 void DrawableTrackBall::setTransform(const vcl::Matrix44f& mtx)
@@ -167,7 +168,8 @@ void DrawableTrackBall::draw(const DrawObjectSettings& settings) const
 
         bgfx::setTransform(mTransform.data());
 
-        mUniforms.bind();
+        DrawableTrackballUniforms::setDragging(mIsDragging);
+        DrawableTrackballUniforms::bind();
 
         bgfx::submit(settings.viewId, pm.getProgram<DRAWABLE_TRACKBALL>());
     }


### PR DESCRIPTION
For a more consistent usage of uniforms, and to avoid useless construction/destruction, they are used statically across classes.
Classes that manages them provide only static member functions that allow to set them and then bind them in the draw calls. 
No need to store mutable members anymore.