### PR TITLE
Reorganize Buffer APIs

### DIFF
--- a/vclib/render/include/vclib/bgfx/buffers/dynamic_index_buffer.h
+++ b/vclib/render/include/vclib/bgfx/buffers/dynamic_index_buffer.h
@@ -48,6 +48,8 @@ class DynamicIndexBuffer : public GenericBuffer<bgfx::DynamicIndexBufferHandle>
     using Base = GenericBuffer<bgfx::DynamicIndexBufferHandle>;
 
 public:
+    using Base::swap;
+
     /**
      * @brief Empty constructor.
      *

--- a/vclib/render/include/vclib/bgfx/buffers/dynamic_vertex_buffer.h
+++ b/vclib/render/include/vclib/bgfx/buffers/dynamic_vertex_buffer.h
@@ -48,41 +48,15 @@ class DynamicVertexBuffer :
 {
     using Base = GenericBuffer<bgfx::DynamicVertexBufferHandle>;
 
-    bool mCompute = false;
-
 public:
+    using Base::swap;
+
     /**
      * @brief Empty constructor.
      *
      * It creates an invalid DynamicVertexBuffer object.
      */
     DynamicVertexBuffer() = default;
-
-    /**
-     * @brief Swap the content of this object with another DynamicVertexBuffer
-     * object.
-     *
-     * @param[in] other: the other DynamicVertexBuffer object.
-     */
-    void swap(DynamicVertexBuffer& other)
-    {
-        using std::swap;
-        Base::swap(other);
-        swap(mCompute, other.mCompute);
-    }
-
-    friend void swap(DynamicVertexBuffer& a, DynamicVertexBuffer& b)
-    {
-        a.swap(b);
-    }
-
-    /**
-     * @brief Check if the VertexBuffer is used for compute shaders.
-     *
-     * @return true if the VertexBuffer is used for compute shaders, false
-     * otherwise.
-     */
-    bool isCompute() const { return mCompute; }
 
     /**
      * @brief Creates the dynamic vertex buffer data for rendering, with the
@@ -172,19 +146,16 @@ public:
      * @param[in] vertNum: the number of vertices in the buffer.
      * @param[in] layout: the vertex layout.
      * @param[in] flags: the flags for the buffer.
-     * @param[in] compute: if true, the buffer is used for compute shaders.
      */
     void create(
         uint                      vertNum,
         const bgfx::VertexLayout& layout,
-        uint64_t                  flags   = BGFX_BUFFER_NONE,
-        bool                      compute = false)
+        uint64_t                  flags   = BGFX_BUFFER_NONE)
     {
         destroy();
 
         if (vertNum != 0)
             mHandle = bgfx::createDynamicVertexBuffer(vertNum, layout, flags);
-        mCompute = compute;
     }
 
     /**
@@ -235,17 +206,13 @@ public:
     /**
      * @brief Bind the dynamic vertex buffer to the rendering pipeline.
      *
-     * @param[in] stream: the stream (or stage, in case of compute) to which the
-     * dynamic vertex buffer is bound.
-     * @param[in] access: the access type for the buffer (only for compute).
+     * @param[in] stream: the stream to which the dynamic vertex buffer is
+     * bound.
      */
-    void bind(uint stream, bgfx::Access::Enum access = bgfx::Access::Read) const
+    void bind(uint stream) const
     {
         if (bgfx::isValid(mHandle)) {
-            if (!mCompute)
                 bgfx::setVertexBuffer(stream, mHandle);
-            else
-                bgfx::setBuffer(stream, mHandle, access);
         }
     }
 

--- a/vclib/render/include/vclib/bgfx/buffers/index_buffer.h
+++ b/vclib/render/include/vclib/bgfx/buffers/index_buffer.h
@@ -43,9 +43,9 @@ class IndexBuffer : public GenericBuffer<bgfx::IndexBufferHandle>
 {
     using Base = GenericBuffer<bgfx::IndexBufferHandle>;
 
-    bool mCompute = false;
-
 public:
+    using Base::swap;
+
     /**
      * @brief Empty constructor.
      *
@@ -54,74 +54,8 @@ public:
     IndexBuffer() = default;
 
     /**
-     * @brief Swap the content of this object with another IndexBuffer object.
-     *
-     * @param[in] other: the other IndexBuffer object.
-     */
-    void swap(IndexBuffer& other)
-    {
-        using std::swap;
-        Base::swap(other);
-        swap(mCompute, other.mCompute);
-    }
-
-    friend void swap(IndexBuffer& a, IndexBuffer& b) { a.swap(b); }
-
-    /**
-     * @brief Check if the IndexBuffer is used for compute shaders.
-     *
-     * @return true if the IndexBuffer is used for compute shaders, false
-     * otherwise.
-     */
-    bool isCompute() const { return mCompute; }
-
-    /**
-     * @brief Set if the IndexBuffer is used for compute shaders.
-     *
-     * @param[in] compute: if true, the IndexBuffer is used for compute
-     * shaders.
-     */
-    void setCompute(bool compute) { mCompute = compute; }
-
-    /**
-     * @brief Creates the index buffer and sets the data for rendering.
-     *
-     * If the buffer is already created (@ref isValid() returns `true`), it is
-     * destroyed and a new one is created.
-     *
-     * @note The data must be available for two bgfx::frame calls, then it is
-     * safe to release the data. If you cannot guarantee this, you must provide
-     * a release function that will be called automatically when the data is no
-     * longer needed.
-     *
-     * @param[in] bufferIndices: the data to be copied in the index buffer.
-     * @param[in] bufferSize: the size of the bufferIndices.
-     * @param[in] is32Bit: if true, the bufferIndices are 32-bit integers.
-     * @param[in] releaseFn: the release function to be called when the data is
-     * no longer needed.
-     */
-    void create(
-        const void*     bufferIndices,
-        const uint      bufferSize,
-        bool            is32Bit   = true,
-        bgfx::ReleaseFn releaseFn = nullptr)
-    {
-        if (bufferSize != 0) {
-            uint64_t flags = is32Bit ? BGFX_BUFFER_INDEX32 : BGFX_BUFFER_NONE;
-            uint     size  = is32Bit ? 4 : 2;
-            create(
-                bgfx::makeRef(bufferIndices, bufferSize * size, releaseFn),
-                flags);
-        }
-        else {
-            if (releaseFn)
-                releaseFn((void*) bufferIndices, nullptr);
-            destroy();
-        }
-    }
-
-    /**
-     * @brief Creates the index buffer and sets the data for compute shaders.
+     * @brief Creates the index buffer and sets the data for rendering or
+     * compute.
      *
      * If the buffer is already created (@ref isValid() returns `true`), it is
      * destroyed and a new one is created.
@@ -138,7 +72,7 @@ public:
      * @param[in] releaseFn: the release function to be called when the data is
      * no longer needed.
      */
-    void createForCompute(
+    void create(
         const void*        bufferIndices,
         const uint         bufferSize,
         PrimitiveType      type,
@@ -151,14 +85,69 @@ public:
             create(
                 bgfx::makeRef(
                     bufferIndices, bufferSize * sizeOf(type), releaseFn),
-                flags,
-                true);
+                flags);
         }
         else {
             if (releaseFn)
                 releaseFn((void*) bufferIndices, nullptr);
             destroy();
         }
+    }
+
+    /**
+     * @brief Creates the index buffer and sets the data for rendering or
+     * compute.
+     *
+     * The access type is assumed to be Read.
+     *
+     * @note The data must be available for two bgfx::frame calls, then it is
+     * safe to release the data. If you cannot guarantee this, you must provide
+     * a release function that will be called automatically when the data is no
+     * longer needed.
+     *
+     * @param[in] bufferIndices: the data to be copied in the index buffer.
+     * @param[in] bufferSize: the size of the bufferIndices.
+     * @param[in] type: the type of the elements.
+     * @param[in] releaseFn: the release function to be called when the data is
+     * no longer needed.
+     */
+    void create(
+        const void*        bufferIndices,
+        const uint         bufferSize,
+        PrimitiveType      type,
+        bgfx::ReleaseFn    releaseFn)
+    {
+        create(bufferIndices, bufferSize, type, bgfx::Access::Read, releaseFn);
+    }
+
+    /**
+     * @brief Creates the index buffer and sets the data for rendering or
+     * compute.
+     *
+     * The type is assumed to be UINT, and the access type is assumed to be
+     * Read.
+     *
+     * @note The data must be available for two bgfx::frame calls, then it is
+     * safe to release the data. If you cannot guarantee this, you must provide
+     * a release function that will be called automatically when the data is no
+     * longer needed.
+     *
+     * @param[in] bufferIndices: the data to be copied in the index buffer.
+     * @param[in] bufferSize: the size of the bufferIndices.
+     * @param[in] releaseFn: the release function to be called when the data is
+     * no longer needed.
+     */
+    void create(
+        const void*        bufferIndices,
+        const uint         bufferSize,
+        bgfx::ReleaseFn    releaseFn = nullptr)
+    {
+        create(
+            bufferIndices,
+            bufferSize,
+            PrimitiveType::UINT,
+            bgfx::Access::Read,
+            releaseFn);
     }
 
     /**
@@ -169,18 +158,13 @@ public:
      *
      * @param[in] indices: the memory containing the data.
      * @param[in] flags: the flags for the buffer.
-     * @param[in] compute: if true, the buffer is used for compute shaders.
      */
-    void create(
-        const bgfx::Memory* indices,
-        uint64_t            flags   = BGFX_BUFFER_NONE,
-        bool                compute = false)
+    void create(const bgfx::Memory* indices, uint64_t flags = BGFX_BUFFER_NONE)
     {
         destroy();
 
         mHandle = bgfx::createIndexBuffer(indices, flags);
         assert(bgfx::isValid(mHandle));
-        mCompute = compute;
     }
 
     /**

--- a/vclib/render/include/vclib/bgfx/buffers/vertex_buffer.h
+++ b/vclib/render/include/vclib/bgfx/buffers/vertex_buffer.h
@@ -43,9 +43,9 @@ class VertexBuffer : public GenericBuffer<bgfx::VertexBufferHandle>
 {
     using Base = GenericBuffer<bgfx::VertexBufferHandle>;
 
-    bool mCompute = false;
-
 public:
+    using Base::swap;
+
     /**
      * @brief Empty constructor.
      *
@@ -54,90 +54,8 @@ public:
     VertexBuffer() = default;
 
     /**
-     * @brief Swap the content of this object with another VertexBuffer object.
-     *
-     * @param[in] other: the other VertexBuffer object.
-     */
-    void swap(VertexBuffer& other)
-    {
-        using std::swap;
-        Base::swap(other);
-        swap(mCompute, other.mCompute);
-    }
-
-    friend void swap(VertexBuffer& a, VertexBuffer& b) { a.swap(b); }
-
-    /**
-     * @brief Check if the VertexBuffer is used for compute shaders.
-     *
-     * @return true if the VertexBuffer is used for compute shaders, false
-     * otherwise.
-     */
-    bool isCompute() const { return mCompute; }
-
-    /**
-     * @brief Set if the VertexBuffer is used for compute shaders.
-     *
-     * @param[in] compute: if true, the VertexBuffer is used for compute
-     * shaders.
-     */
-    void setCompute(bool compute) { mCompute = compute; }
-
-    /**
-     * @brief Creates the vertex buffer and sets the data for rendering.
-     *
-     * If the buffer is already created (@ref isValid() returns `true`), it is
-     * destroyed and a new one is created.
-     *
-     * @note The data must be available for two bgfx::frame calls, then it is
-     * safe to release the data. If you cannot guarantee this, you must provide
-     * a release function that will be called automatically when the data is no
-     * longer needed.
-     *
-     * @param[in] bufferData: the data to be copied in the vertex buffer.
-     * @param[in] vertNum: the number of vertices in the buffer.
-     * @param[in] attrib: the attribute to which the data of the buffer refers.
-     * @param[in] attribNumPerVertex: the number of attributes per vertex.
-     * @param[in] attribType: the type of the attributes.
-     * @param[in] normalize: if true, the data is normalized.
-     * @param[in] releaseFn: the release function to be called when the data is
-     * no longer needed.
-     */
-    void create(
-        const void*        bufferData,
-        uint               vertNum,
-        bgfx::Attrib::Enum attrib,
-        uint               attribNumPerVertex,
-        PrimitiveType      attribType,
-        bool               normalize = false,
-        bgfx::ReleaseFn    releaseFn = nullptr)
-    {
-        if (vertNum != 0) {
-            bgfx::VertexLayout layout;
-            layout.begin()
-                .add(
-                    attrib,
-                    attribNumPerVertex,
-                    attributeType(attribType),
-                    normalize)
-                .end();
-
-            create(
-                bgfx::makeRef(
-                    bufferData,
-                    vertNum * attribNumPerVertex * sizeOf(attribType),
-                    releaseFn),
-                layout);
-        }
-        else {
-            if (releaseFn)
-                releaseFn((void*) bufferData, nullptr);
-            destroy();
-        }
-    }
-
-    /**
-     * @brief Creates the vertex buffer and sets the data for compute shaders.
+     * @brief Creates the vertex buffer and sets the data for rendering or
+     * compute.
      *
      * If the buffer is already created (@ref isValid() returns `true`), it is
      * destroyed and a new one is created.
@@ -157,7 +75,7 @@ public:
      * @param[in] releaseFn: the release function to be called when the data is
      * no longer needed.
      */
-    void createForCompute(
+    void create(
         const void*        bufferData,
         const uint         vertNum,
         bgfx::Attrib::Enum attrib,
@@ -186,14 +104,97 @@ public:
                     vertNum * attribNumPerVertex * sizeOf(attribType),
                     releaseFn),
                 layout,
-                flags,
-                true);
+                flags);
         }
         else {
             if (releaseFn)
                 releaseFn((void*) bufferData, nullptr);
             destroy();
         }
+    }
+
+    /**
+     * @brief Creates the vertex buffer and sets the data for rendering or
+     * compute.
+     *
+     * If the buffer is already created (@ref isValid() returns `true`), it is
+     * destroyed and a new one is created.
+     *
+     * The access type is assumed to be Read.
+     *
+     * @note The data must be available for two bgfx::frame calls, then it is
+     * safe to release the data. If you cannot guarantee this, you must provide
+     * a release function that will be called automatically when the data is no
+     * longer needed.
+     *
+     * @param[in] bufferData: the data to be copied in the vertex buffer.
+     * @param[in] vertNum: the number of vertices in the buffer.
+     * @param[in] attrib: the attribute to which the data of the buffer refers.
+     * @param[in] attribNumPerVertex: the number of attributes per vertex.
+     * @param[in] attribType: the type of the attributes.
+     * @param[in] normalize: if true, the data is normalized.
+     * @param[in] releaseFn: the release function to be called when the data is
+     * no longer needed.
+     */
+    void create(
+        const void*        bufferData,
+        const uint         vertNum,
+        bgfx::Attrib::Enum attrib,
+        uint               attribNumPerVertex,
+        PrimitiveType      attribType,
+        bool               normalize,
+        bgfx::ReleaseFn    releaseFn = nullptr)
+    {
+        create(
+            bufferData,
+            vertNum,
+            attrib,
+            attribNumPerVertex,
+            attribType,
+            normalize,
+            bgfx::Access::Read,
+            releaseFn);
+    }
+
+    /**
+     * @brief Creates the vertex buffer and sets the data for rendering or
+     * compute.
+     *
+     * If the buffer is already created (@ref isValid() returns `true`), it is
+     * destroyed and a new one is created.
+     *
+     * The access type is assumed to be Read, and the data is not normalized.
+     *
+     * @note The data must be available for two bgfx::frame calls, then it is
+     * safe to release the data. If you cannot guarantee this, you must provide
+     * a release function that will be called automatically when the data is no
+     * longer needed.
+     *
+     * @param[in] bufferData: the data to be copied in the vertex buffer.
+     * @param[in] vertNum: the number of vertices in the buffer.
+     * @param[in] attrib: the attribute to which the data of the buffer refers.
+     * @param[in] attribNumPerVertex: the number of attributes per vertex.
+     * @param[in] attribType: the type of the attributes.
+     * @param[in] releaseFn: the release function to be called when the data is
+     * no longer needed.
+     */
+    void create(
+        const void*        bufferData,
+        const uint         vertNum,
+        bgfx::Attrib::Enum attrib,
+        uint               attribNumPerVertex,
+        PrimitiveType      attribType,
+        bgfx::ReleaseFn    releaseFn)
+    {
+        create(
+            bufferData,
+            vertNum,
+            attrib,
+            attribNumPerVertex,
+            attribType,
+            false,
+            bgfx::Access::Read,
+            releaseFn);
     }
 
     /**
@@ -205,19 +206,16 @@ public:
      * @param[in] data: the memory containing the data.
      * @param[in] layout: the vertex layout.
      * @param[in] flags: the flags for the buffer.
-     * @param[in] compute: if true, the buffer is used for compute shaders.
      */
     void create(
         const bgfx::Memory*       data,
         const bgfx::VertexLayout& layout,
-        uint64_t                  flags   = BGFX_BUFFER_NONE,
-        bool                      compute = false)
+        uint64_t                  flags   = BGFX_BUFFER_NONE)
     {
         destroy();
 
         mHandle = bgfx::createVertexBuffer(data, layout, flags);
         assert(bgfx::isValid(mHandle));
-        mCompute = compute;
     }
 
     /**
@@ -227,15 +225,11 @@ public:
      *
      * @param[in] stream: the stream (or stage, in case of compute) to which the
      * vertex buffer is bound.
-     * @param[in] access: the access type for the buffer (only for compute).
      */
-    void bind(uint stream, bgfx::Access::Enum access = bgfx::Access::Read) const
+    void bind(uint stream) const
     {
         if (bgfx::isValid(mHandle)) {
-            if (!mCompute)
-                bgfx::setVertexBuffer(stream, mHandle);
-            else
-                bgfx::setBuffer(stream, mHandle, access);
+            bgfx::setVertexBuffer(stream, mHandle);
         }
     }
 
@@ -256,13 +250,6 @@ public:
     {
         if (bgfx::isValid(mHandle)) {
             bgfx::setBuffer(stage, mHandle, access);
-        }
-    }
-
-    void bindVertex(uint stream) const
-    {
-        if (bgfx::isValid(mHandle)) {
-            bgfx::setVertexBuffer(stream, mHandle);
         }
     }
 };

--- a/vclib/render/include/vclib/bgfx/drawable/mesh/mesh_render_buffers.h
+++ b/vclib/render/include/vclib/bgfx/drawable/mesh/mesh_render_buffers.h
@@ -391,7 +391,7 @@ private:
 
         Base::fillVertexQuadIndices(mesh, buffer);
 
-        mVertexQuadIndexBuffer.create(buffer, totalIndices, true, releaseFn);
+        mVertexQuadIndexBuffer.create(buffer, totalIndices, releaseFn);
 
         // if number of vertices is not zero, the index buffer must be valid
         assert(mVertexQuadIndexBuffer.isValid() || totalIndices == 0);
@@ -508,7 +508,7 @@ private:
         // pre-triangulation estimate for meshes with degenerate faces.
         nt = Base::numTris();
 
-        mTriangleIndexBuffer.create(buffer, nt * 3, true, releaseFn);
+        mTriangleIndexBuffer.create(buffer, nt * 3, releaseFn);
     }
 
     void setTriangleNormalsBuffer(const MeshType& mesh) // override
@@ -520,12 +520,8 @@ private:
 
         Base::fillTriangleNormals(mesh, buffer);
 
-        mTriangleNormalBuffer.createForCompute(
-            buffer,
-            nt * 3,
-            PrimitiveType::FLOAT,
-            bgfx::Access::Read,
-            releaseFn);
+        mTriangleNormalBuffer.create(
+            buffer, nt * 3, PrimitiveType::FLOAT, releaseFn);
     }
 
     void setTriangleColorsBuffer(const MeshType& mesh) // override
@@ -537,8 +533,7 @@ private:
 
         Base::fillTriangleColors(mesh, buffer, Color::Format::ABGR);
 
-        mTriangleColorBuffer.createForCompute(
-            buffer, nt, PrimitiveType::UINT, bgfx::Access::Read, releaseFn);
+        mTriangleColorBuffer.create(buffer, nt, releaseFn);
     }
 
     void setEdgeIndicesBuffer(const MeshType& mesh) // override

--- a/vclib/render/include/vclib/bgfx/drawable/mesh/mesh_render_buffers.h
+++ b/vclib/render/include/vclib/bgfx/drawable/mesh/mesh_render_buffers.h
@@ -169,12 +169,12 @@ public:
 
         // streams MUST be consecutive starting from 0
         // otherwise on metal it won't work
-        mVertexPositionsBuffer.bindVertex(stream++);
+        mVertexPositionsBuffer.bind(stream++);
 
         if (mVertexNormalsBuffer.isValid()) {
             // bgfx limitation
             assert(stream < bgfx::getCaps()->limits.maxVertexStreams);
-            mVertexNormalsBuffer.bindVertex(stream++);
+            mVertexNormalsBuffer.bind(stream++);
         }
 
         if (mVertexTangentsBuffer.isValid()) {
@@ -186,7 +186,7 @@ public:
         if (mVertexColorsBuffer.isValid()) {
             // bgfx limitation
             assert(stream < bgfx::getCaps()->limits.maxVertexStreams);
-            mVertexColorsBuffer.bindVertex(stream++);
+            mVertexColorsBuffer.bind(stream++);
         }
 
         if (mVertexUVBuffer.isValid() && mrs.isSurface(COLOR_VERTEX_TEX)) {
@@ -342,14 +342,12 @@ private:
 
         Base::fillVertexPositions(mesh, buffer);
 
-        mVertexPositionsBuffer.createForCompute(
+        mVertexPositionsBuffer.create(
             buffer,
             nv,
             bgfx::Attrib::Position,
             3,
             PrimitiveType::FLOAT,
-            false,
-            bgfx::Access::Read,
             releaseFn);
 
         // Creates the buffers to be used with compute for splatting
@@ -406,14 +404,12 @@ private:
 
         Base::fillVertexNormals(mesh, buffer);
 
-        mVertexNormalsBuffer.createForCompute(
+        mVertexNormalsBuffer.create(
             buffer,
             nv,
             bgfx::Attrib::Normal,
             3,
             PrimitiveType::FLOAT,
-            false,
-            bgfx::Access::Read,
             releaseFn);
     }
 
@@ -426,14 +422,13 @@ private:
 
         Base::fillVertexColors(mesh, buffer, Color::Format::ABGR);
 
-        mVertexColorsBuffer.createForCompute(
+        mVertexColorsBuffer.create(
             buffer,
             nv,
             bgfx::Attrib::Color0,
             4,
             PrimitiveType::UCHAR,
             true,
-            bgfx::Access::Read,
             releaseFn);
     }
 
@@ -452,7 +447,6 @@ private:
             bgfx::Attrib::TexCoord0,
             2,
             PrimitiveType::FLOAT,
-            false,
             releaseFn);
     }
 
@@ -471,7 +465,6 @@ private:
             bgfx::Attrib::Tangent,
             4,
             PrimitiveType::FLOAT,
-            false,
             releaseFn);
     }
 
@@ -490,7 +483,6 @@ private:
             bgfx::Attrib::TexCoord1,
             2,
             PrimitiveType::FLOAT,
-            false,
             releaseFn);
     }
 

--- a/vclib/render/include/vclib/bgfx/screenspace/primitives/screenspace_lines.h
+++ b/vclib/render/include/vclib/bgfx/screenspace/primitives/screenspace_lines.h
@@ -181,12 +181,7 @@ public:
             ++i;
         }
 
-        indexBuff.createForCompute(
-            buffer,
-            mIndexCount,
-            PrimitiveType::UINT,
-            bgfx::Access::Read,
-            releaseFn);
+        indexBuff.create(buffer, mIndexCount, releaseFn);
 
         mIndices.setOwned(std::move(indexBuff));
     }
@@ -246,13 +241,7 @@ public:
             ++i;
         }
 
-        // Use createForCompute to enable SSBO binding for vertex pulling
-        lColsBuff.createForCompute(
-            buffer,
-            mLineColorCount,
-            PrimitiveType::UINT,
-            bgfx::Access::Read,
-            releaseFn);
+        lColsBuff.create(buffer, mLineColorCount, releaseFn);
         mLineColors.setOwned(std::move(lColsBuff));
     }
 

--- a/vclib/render/include/vclib/bgfx/screenspace/primitives/screenspace_lines.h
+++ b/vclib/render/include/vclib/bgfx/screenspace/primitives/screenspace_lines.h
@@ -140,14 +140,12 @@ public:
         }
 
         // Use createForCompute to enable SSBO binding for vertex pulling
-        vertBuff.createForCompute(
+        vertBuff.create(
             buffer,
             nv,
             bgfx::Attrib::Position,
             2,
             PrimitiveType::FLOAT,
-            false,
-            bgfx::Access::Read,
             releaseFn);
         mVertexPositions.setOwned(std::move(vertBuff));
     }
@@ -212,14 +210,13 @@ public:
         }
 
         // Use createForCompute to enable SSBO binding for vertex pulling
-        vColsBuff.createForCompute(
+        vColsBuff.create(
             buffer,
             mVerPosCount,
             bgfx::Attrib::Color0,
             4,
             PrimitiveType::UCHAR,
             true,
-            bgfx::Access::Read,
             releaseFn);
         mVertexColors.setOwned(std::move(vColsBuff));
     }

--- a/vclib/render/include/vclib/bgfx/screenspace/primitives/screenspace_points.h
+++ b/vclib/render/include/vclib/bgfx/screenspace/primitives/screenspace_points.h
@@ -133,14 +133,12 @@ public:
             ++i;
         }
 
-        vertBuff.createForCompute(
+        vertBuff.create(
             buffer,
             nv,
             bgfx::Attrib::Position,
             2,
             PrimitiveType::FLOAT,
-            false,
-            bgfx::Access::Read,
             releaseFn);
         mVertexPositions.setOwned(std::move(vertBuff));
     }
@@ -168,14 +166,13 @@ public:
             ++i;
         }
 
-        vColsBuff.createForCompute(
+        vColsBuff.create(
             buffer,
             mVertexCount,
             bgfx::Attrib::Color0,
             4,
             PrimitiveType::UCHAR,
             true,
-            bgfx::Access::Read,
             releaseFn);
         mVertexColors.setOwned(std::move(vColsBuff));
     }

--- a/vclib/render/src/vclib/bgfx/drawable/drawable_environment.cpp
+++ b/vclib/render/src/vclib/bgfx/drawable/drawable_environment.cpp
@@ -73,7 +73,7 @@ void DrawableEnvironment::drawBackground(
         using enum TextureType;
         bindTexture(RAW_CUBE, VCL_MRB_CUBEMAP0);
 
-        mVertexBuffer.bindVertex(0);
+        mVertexBuffer.bind(0);
 
         bgfx::setState(BGFX_STATE_WRITE_MASK | BGFX_STATE_DEPTH_TEST_LEQUAL);
 
@@ -443,8 +443,7 @@ vcl::VertexBuffer DrawableEnvironment::fullScreenTriangle()
         3,
         bgfx::Attrib::Enum::Position,
         3,
-        vcl::PrimitiveType::FLOAT,
-        false);
+        vcl::PrimitiveType::FLOAT);
     return vb;
 }
 

--- a/vclib/render/src/vclib/bgfx/drawable/drawable_trackball.cpp
+++ b/vclib/render/src/vclib/bgfx/drawable/drawable_trackball.cpp
@@ -220,7 +220,9 @@ void DrawableTrackBall::createBuffers()
 
     // edge index buffer
     mEdgeIndexBuffer.create(
-        TRACKBALL_DATA.second.data(), TRACKBALL_DATA.second.size(), false);
+        TRACKBALL_DATA.second.data(),
+        TRACKBALL_DATA.second.size(),
+        PrimitiveType::USHORT);
 }
 
 } // namespace vcl

--- a/vclib/render/src/vclib/bgfx/primitives/lines/cpu_generated_lines.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/lines/cpu_generated_lines.cpp
@@ -247,12 +247,7 @@ void CPUGeneratedLines::setPoints(
 
             std::copy(lineColors.begin(), lineColors.end(), l);
 
-            mLineColors.createForCompute(
-                l,
-                lineColors.size(),
-                PrimitiveType::UINT,
-                bgfx::Access::Read,
-                lineColorsReleaseFn);
+            mLineColors.create(l, lineColors.size(), lineColorsReleaseFn);
         }
 
         mIndices.create(

--- a/vclib/render/src/vclib/bgfx/primitives/lines/primitive_lines.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/lines/primitive_lines.cpp
@@ -279,12 +279,7 @@ void PrimitiveLines::setPoints(
             std::copy(lineColors.begin(), lineColors.end(), lColors);
 
             IndexBuffer tmpLC;
-            tmpLC.createForCompute(
-                lColors,
-                lineColors.size(),
-                PrimitiveType::UINT,
-                bgfx::Access::Read,
-                lColorsReleaseFn);
+            tmpLC.create(lColors, lineColors.size(), lColorsReleaseFn);
             mLineColors.setOwned(std::move(tmpLC));
         }
     }

--- a/vclib/render/src/vclib/bgfx/read_from_gpu_buffer.cpp
+++ b/vclib/render/src/vclib/bgfx/read_from_gpu_buffer.cpp
@@ -331,9 +331,9 @@ uint ReadFromGPUBuffer::submit(
                      "non-COMPUTE_BUFFER instance\n";
         return 0;
     }
-    if (!buf.isValid() || !buf.isCompute()) {
+    if (!buf.isValid()) {
         std::cerr << "ReadFromGPUBuffer::submit(IndexBuffer): buffer is "
-                     "invalid or not compute-capable\n";
+                     "invalid\n";
         return 0;
     }
     if (!bgfx::isValid(mGPUTexHandle) || !bgfx::isValid(mCPUTexHandle)) {


### PR DESCRIPTION
This PR consolidates the buffer creation API across `IndexBuffer`, `VertexBuffer`, and `DynamicVertexBuffer` classes by removing the separate `createForCompute()` methods and the internal `mCompute` flag. The new unified `create()` overloads handle both rendering and compute shader use cases through explicit `PrimitiveType` and `bgfx::Access::Enum` parameters.

## Key Design Decisions

1. **Unified `create()` API**: Instead of separate `create()` (render) and `createForCompute()` methods, all buffer classes now use overloaded `create()` methods. The access type is passed explicitly via `bgfx::Access::Enum`.

2. **Removed `mCompute` flag**: The internal boolean tracking whether a buffer is for compute was redundant. BGFX's `bgfx::setBuffer()` vs `bgfx::setVertexBuffer()` handles the distinction at bind time when needed.

3. **Delegated `swap()` to Base**: Custom swap implementations that also swapped `mCompute` were removed. The `using Base::swap;` declaration delegates to the parent `GenericBuffer` class.

4. **Simplified `bind()`**: The `bind()` method no longer takes an `access` parameter. For standard vertex buffer binding, `bgfx::setVertexBuffer()` is used directly. Compute-specific binding via `bgfx::setBuffer()` is available through a separate overload when needed.