### PR TITLE
Add Primitive Points Rendering

### DIFF
--- a/examples/render/09-drawable-points/CMakeLists.txt
+++ b/examples/render/09-drawable-points/CMakeLists.txt
@@ -20,48 +20,6 @@
 #* (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
 #****************************************************************************/
 
-project(vclib-render-examples)
-
-set(CMAKE_COMPILE_WARNING_AS_ERROR ${VCLIB_COMPILE_WARNINGS_AS_ERRORS})
-
 if (TARGET vclib-3rd-qt)
-    add_compile_definitions(VCLIB_RENDER_EXAMPLES_WITH_QT)
-    set(CAN_BUILD_VCLIB_RENDER_EXAMPLES true)
-endif()
-if(TARGET vclib-3rd-glfw)
-    if (NOT CAN_BUILD_VCLIB_RENDER_EXAMPLES)
-        add_compile_definitions(VCLIB_RENDER_EXAMPLES_WITH_GLFW)
-        set(CAN_BUILD_VCLIB_RENDER_EXAMPLES true)
-    endif()
-endif()
-
-if (CAN_BUILD_VCLIB_RENDER_EXAMPLES)
-    add_subdirectory(common)
-
-    add_subdirectory(00-hello-triangle)
-    add_subdirectory(01-viewer)
-    add_subdirectory(02-mesh-viewer)
-    add_subdirectory(03-viewer-with-text)
-    add_subdirectory(04-hello-triangle-imgui)
-    add_subdirectory(05-two-window-viewers)
-    add_subdirectory(06-viewer-imgui)
-    add_subdirectory(07-test-texcoords)
-    add_subdirectory(08-test-gltf)
-
-    add_subdirectory(801-camera-viewer)
-    add_subdirectory(808-test-lines)
-
-    if (VCLIB_RENDER_BACKEND STREQUAL "bgfx")
-        add_subdirectory(09-drawable-points)
-        add_subdirectory(800-screenspace)
-        add_subdirectory(950-pbr)
-    endif()
-
-    add_subdirectory(999-misc)
-
-    add_subdirectory(core)
-
-    if (VCLIB_BUILD_MODULE_EXTERNAL)
-        add_subdirectory(external)
-    endif()
+    add_subdirectory(qt)
 endif()

--- a/examples/render/09-drawable-points/qt/CMakeLists.txt
+++ b/examples/render/09-drawable-points/qt/CMakeLists.txt
@@ -20,48 +20,12 @@
 #* (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
 #****************************************************************************/
 
-project(vclib-render-examples)
+set(EXAMPLE_NAME 09-drawable-points-qt)
+project(vclib-render-example-${EXAMPLE_NAME})
 
-set(CMAKE_COMPILE_WARNING_AS_ERROR ${VCLIB_COMPILE_WARNINGS_AS_ERRORS})
+set(SOURCES
+    main.cpp)
 
-if (TARGET vclib-3rd-qt)
-    add_compile_definitions(VCLIB_RENDER_EXAMPLES_WITH_QT)
-    set(CAN_BUILD_VCLIB_RENDER_EXAMPLES true)
-endif()
-if(TARGET vclib-3rd-glfw)
-    if (NOT CAN_BUILD_VCLIB_RENDER_EXAMPLES)
-        add_compile_definitions(VCLIB_RENDER_EXAMPLES_WITH_GLFW)
-        set(CAN_BUILD_VCLIB_RENDER_EXAMPLES true)
-    endif()
-endif()
-
-if (CAN_BUILD_VCLIB_RENDER_EXAMPLES)
-    add_subdirectory(common)
-
-    add_subdirectory(00-hello-triangle)
-    add_subdirectory(01-viewer)
-    add_subdirectory(02-mesh-viewer)
-    add_subdirectory(03-viewer-with-text)
-    add_subdirectory(04-hello-triangle-imgui)
-    add_subdirectory(05-two-window-viewers)
-    add_subdirectory(06-viewer-imgui)
-    add_subdirectory(07-test-texcoords)
-    add_subdirectory(08-test-gltf)
-
-    add_subdirectory(801-camera-viewer)
-    add_subdirectory(808-test-lines)
-
-    if (VCLIB_RENDER_BACKEND STREQUAL "bgfx")
-        add_subdirectory(09-drawable-points)
-        add_subdirectory(800-screenspace)
-        add_subdirectory(950-pbr)
-    endif()
-
-    add_subdirectory(999-misc)
-
-    add_subdirectory(core)
-
-    if (VCLIB_BUILD_MODULE_EXTERNAL)
-        add_subdirectory(external)
-    endif()
-endif()
+vclib_add_example(${EXAMPLE_NAME}
+    MODULE render
+    SOURCES ${SOURCES})

--- a/examples/render/09-drawable-points/qt/main.cpp
+++ b/examples/render/09-drawable-points/qt/main.cpp
@@ -31,29 +31,52 @@
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 
-#include <vclib/algorithms/core/random.h>
+#include <vclib/algorithms.h>
+#include <vclib/meshes.h>
+#include <vclib/io.h>
 
 std::shared_ptr<vcl::DrawablePoints> getDrawablePoints(vcl::uint nPoints)
 {
     auto points = std::make_shared<vcl::DrawablePoints>();
 
-    std::vector<vcl::Point3d> positions(nPoints);
-    std::vector<vcl::Color> colors(nPoints);
+    if (nPoints == vcl::UINT_NULL) {
+        // load bimba and use its vertices as points
+        auto m =
+            vcl::loadMesh<vcl::TriMesh>(VCLIB_EXAMPLE_MESHES_PATH "/bimba.obj");
+        vcl::updatePerVertexAndFaceNormals(m);
 
-    for (vcl::uint i = 0; i < nPoints; ++i) {
-        positions[i] = vcl::random<vcl::Point3d>();
-        colors[i] = vcl::Color(
-            vcl::random<uint8_t>(),
-            vcl::random<uint8_t>(),
-            vcl::random<uint8_t>()
-        );
+        std::vector<vcl::Color> colors(m.vertexCount());
+
+        for (vcl::uint i = 0; i < m.vertexCount(); ++i) {
+            colors[i] = vcl::Color(
+                vcl::random<uint8_t>(),
+                vcl::random<uint8_t>(),
+                vcl::random<uint8_t>()
+                );
+        }
+
+        points->setVertices(m.vertices() | vcl::views::positions);
+        points->setVertexColors(colors);
+        points->setVertexNormals(m.vertices() | vcl::views::normals);
+    }
+    else {
+        std::vector<vcl::Point3d> positions(nPoints);
+        std::vector<vcl::Color> colors(nPoints);
+
+        for (vcl::uint i = 0; i < nPoints; ++i) {
+            positions[i] = vcl::random<vcl::Point3d>();
+            colors[i] = vcl::Color(
+                vcl::random<uint8_t>(),
+                vcl::random<uint8_t>(),
+                vcl::random<uint8_t>()
+            );
+        }
+
+        points->setVertices(positions);
+        points->setVertexColors(colors);
     }
 
     points->setSize(10);
-
-    points->setVertices(positions);
-    points->setVertexColors(colors);
-
     points->setColorSetting(vcl::Points::ColorSetting::PER_VERTEX);
     points->setShading(vcl::Points::Shading::NONE);
     points->setShape(vcl::Points::Shape::SQUARE);
@@ -104,7 +127,7 @@ int main(int argc, char** argv)
     QHBoxLayout* shapeLayout = new QHBoxLayout(shapeGroup);
     QRadioButton* rbShapeSquare = new QRadioButton("Square");
     QRadioButton* rbShapeCircle = new QRadioButton("Circle");
-    rbShapeSquare->setChecked(true); // Default from getDrawablePoints
+    rbShapeSquare->setChecked(true);
     shapeLayout->addWidget(rbShapeSquare);
     shapeLayout->addWidget(rbShapeCircle);
 
@@ -113,7 +136,7 @@ int main(int argc, char** argv)
     QHBoxLayout* shadingLayout = new QHBoxLayout(shadingGroup);
     QRadioButton* rbShadingNone = new QRadioButton("None");
     QRadioButton* rbShadingPerVertex = new QRadioButton("Per Vertex");
-    rbShadingNone->setChecked(true); // Default from getDrawablePoints
+    rbShadingNone->setChecked(true);
     shadingLayout->addWidget(rbShadingNone);
     shadingLayout->addWidget(rbShadingPerVertex);
 
@@ -130,7 +153,7 @@ int main(int argc, char** argv)
     std::shared_ptr<vcl::DrawableObjectVector> vec =
         std::make_shared<vcl::DrawableObjectVector>();
 
-    vec->pushBack(getDrawablePoints(N_POINTS));
+    vec->pushBack(getDrawablePoints(vcl::UINT_NULL));
 
     tw->setDrawableObjectVector(vec);
     auto pts = getPoints(vec);

--- a/examples/render/09-drawable-points/qt/main.cpp
+++ b/examples/render/09-drawable-points/qt/main.cpp
@@ -28,6 +28,30 @@
 #include <QComboBox>
 #include <QVBoxLayout>
 
+#include <vclib/algorithms/core/random.h>
+
+std::shared_ptr<vcl::DrawablePoints> getDrawablePoints(vcl::uint nPoints)
+{
+    auto points = std::make_shared<vcl::DrawablePoints>();
+
+    std::vector<vcl::Point3d> positions(nPoints);
+    std::vector<vcl::Color> colors(nPoints);
+
+    for (vcl::uint i = 0; i < nPoints; ++i) {
+        positions[i] = vcl::random<vcl::Point3d>();
+        colors[i] = vcl::Color(
+            vcl::random<uint8_t>(),
+            vcl::random<uint8_t>(),
+            vcl::random<uint8_t>()
+        );
+    }
+
+    points->setVertices(positions);
+    points->setVertexColors(colors);
+
+    return points;
+}
+
 class ColorToUseComboBox : public QComboBox
 {
 public:
@@ -73,10 +97,10 @@ int main(int argc, char** argv)
     std::shared_ptr<vcl::DrawableObjectVector> vec =
         std::make_shared<vcl::DrawableObjectVector>();
 
-    //vec->pushBack(std::move(getDrawablePoints(N_POINTS)));
+    vec->pushBack(getDrawablePoints(N_POINTS));
 
     tw->setDrawableObjectVector(vec);
-    //tslider->setValue(getPoints(vec)->size());
+    tslider->setValue(getPoints(vec)->size());
 
     QObject::connect(
         ccb,
@@ -86,13 +110,13 @@ int main(int argc, char** argv)
 
             std::cerr << "Color to use: " << index << std::endl;
 
-            //getPoints(vec)->setColorSetting((ColorSetting) index);
+            getPoints(vec)->setColorSetting((ColorSetting) index);
             tw->update();
         });
 
     QObject::connect(tslider, &QSlider::valueChanged, [=](int value) {
         std::cerr << "Size: " << value << std::endl;
-        //getPoints(vec)->setSize((float) value);
+        getPoints(vec)->setSize((float) value);
         tw->update();
     });
 

--- a/examples/render/09-drawable-points/qt/main.cpp
+++ b/examples/render/09-drawable-points/qt/main.cpp
@@ -53,6 +53,7 @@ std::shared_ptr<vcl::DrawablePoints> getDrawablePoints(vcl::uint nPoints)
 
     points->setColorSetting(vcl::Points::ColorSetting::PER_VERTEX);
     points->setShading(vcl::Points::Shading::NONE);
+    points->setShape(vcl::Points::Shape::SQUARE);
 
     return points;
 }
@@ -105,7 +106,7 @@ int main(int argc, char** argv)
     vec->pushBack(getDrawablePoints(N_POINTS));
 
     tw->setDrawableObjectVector(vec);
-    tslider->setValue(getPoints(vec)->size());
+    tslider->setValue(getPoints(vec)->width());
 
     QObject::connect(
         ccb,

--- a/examples/render/09-drawable-points/qt/main.cpp
+++ b/examples/render/09-drawable-points/qt/main.cpp
@@ -26,6 +26,9 @@
 
 #include <QCheckBox>
 #include <QComboBox>
+#include <QGroupBox>
+#include <QRadioButton>
+#include <QHBoxLayout>
 #include <QVBoxLayout>
 
 #include <vclib/algorithms/core/random.h>
@@ -54,6 +57,7 @@ std::shared_ptr<vcl::DrawablePoints> getDrawablePoints(vcl::uint nPoints)
     points->setColorSetting(vcl::Points::ColorSetting::PER_VERTEX);
     points->setShading(vcl::Points::Shading::NONE);
     points->setShape(vcl::Points::Shape::SQUARE);
+    points->setGeneralColor(vcl::Color::Magenta);
 
     return points;
 }
@@ -95,6 +99,29 @@ int main(int argc, char** argv)
     tslider->setValue(5);
     layout->addWidget(tslider);
 
+    QGroupBox* shapeGroup = new QGroupBox("Shape");
+    shapeGroup->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
+    QHBoxLayout* shapeLayout = new QHBoxLayout(shapeGroup);
+    QRadioButton* rbShapeSquare = new QRadioButton("Square");
+    QRadioButton* rbShapeCircle = new QRadioButton("Circle");
+    rbShapeSquare->setChecked(true); // Default from getDrawablePoints
+    shapeLayout->addWidget(rbShapeSquare);
+    shapeLayout->addWidget(rbShapeCircle);
+
+    QGroupBox* shadingGroup = new QGroupBox("Shading");
+    shadingGroup->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
+    QHBoxLayout* shadingLayout = new QHBoxLayout(shadingGroup);
+    QRadioButton* rbShadingNone = new QRadioButton("None");
+    QRadioButton* rbShadingPerVertex = new QRadioButton("Per Vertex");
+    rbShadingNone->setChecked(true); // Default from getDrawablePoints
+    shadingLayout->addWidget(rbShadingNone);
+    shadingLayout->addWidget(rbShadingPerVertex);
+
+    QHBoxLayout* radioLayout = new QHBoxLayout();
+    radioLayout->addWidget(shapeGroup);
+    radioLayout->addWidget(shadingGroup);
+    layout->addLayout(radioLayout);
+
     vcl::qt::ViewerWidget* tw = new vcl::qt::ViewerWidget(&w);
     layout->addWidget(tw);
 
@@ -106,7 +133,10 @@ int main(int argc, char** argv)
     vec->pushBack(getDrawablePoints(N_POINTS));
 
     tw->setDrawableObjectVector(vec);
-    tslider->setValue(getPoints(vec)->width());
+    auto pts = getPoints(vec);
+    tslider->setValue(pts->width());
+    
+    shadingGroup->setEnabled(pts->hasNormals());
 
     QObject::connect(
         ccb,
@@ -124,6 +154,34 @@ int main(int argc, char** argv)
         std::cerr << "Size: " << value << std::endl;
         getPoints(vec)->setSize((float) value);
         tw->update();
+    });
+
+    QObject::connect(rbShapeSquare, &QRadioButton::toggled, [=](bool checked) {
+        if (checked) {
+            getPoints(vec)->setShape(vcl::Points::Shape::SQUARE);
+            tw->update();
+        }
+    });
+
+    QObject::connect(rbShapeCircle, &QRadioButton::toggled, [=](bool checked) {
+        if (checked) {
+            getPoints(vec)->setShape(vcl::Points::Shape::CIRCLE);
+            tw->update();
+        }
+    });
+
+    QObject::connect(rbShadingNone, &QRadioButton::toggled, [=](bool checked) {
+        if (checked) {
+            getPoints(vec)->setShading(vcl::Points::Shading::NONE);
+            tw->update();
+        }
+    });
+
+    QObject::connect(rbShadingPerVertex, &QRadioButton::toggled, [=](bool checked) {
+        if (checked) {
+            getPoints(vec)->setShading(vcl::Points::Shading::PER_VERTEX);
+            tw->update();
+        }
     });
 
     w.resize(1024, 768);

--- a/examples/render/09-drawable-points/qt/main.cpp
+++ b/examples/render/09-drawable-points/qt/main.cpp
@@ -46,8 +46,13 @@ std::shared_ptr<vcl::DrawablePoints> getDrawablePoints(vcl::uint nPoints)
         );
     }
 
+    points->setSize(10);
+
     points->setVertices(positions);
     points->setVertexColors(colors);
+
+    points->setColorSetting(vcl::Points::ColorSetting::PER_VERTEX);
+    points->setShading(vcl::Points::Shading::NONE);
 
     return points;
 }

--- a/examples/render/09-drawable-points/qt/main.cpp
+++ b/examples/render/09-drawable-points/qt/main.cpp
@@ -40,41 +40,34 @@ std::shared_ptr<vcl::DrawablePoints> getDrawablePoints(vcl::uint nPoints)
     auto points = std::make_shared<vcl::DrawablePoints>();
 
     if (nPoints == vcl::UINT_NULL) {
-        // load bimba and use its vertices as points
+        // load bunny and use its vertices as points
         auto m =
-            vcl::loadMesh<vcl::TriMesh>(VCLIB_EXAMPLE_MESHES_PATH "/bimba.obj");
+            vcl::loadMesh<vcl::TriMesh>(VCLIB_EXAMPLE_MESHES_PATH "/bunny.obj");
         vcl::updatePerVertexAndFaceNormals(m);
 
-        std::vector<vcl::Color> colors(m.vertexCount());
-
-        for (vcl::uint i = 0; i < m.vertexCount(); ++i) {
-            colors[i] = vcl::Color(
-                vcl::random<uint8_t>(),
-                vcl::random<uint8_t>(),
-                vcl::random<uint8_t>()
-                );
-        }
+        nPoints = m.vertexCount();
 
         points->setVertices(m.vertices() | vcl::views::positions);
-        points->setVertexColors(colors);
         points->setVertexNormals(m.vertices() | vcl::views::normals);
     }
     else {
         std::vector<vcl::Point3d> positions(nPoints);
-        std::vector<vcl::Color> colors(nPoints);
 
         for (vcl::uint i = 0; i < nPoints; ++i) {
             positions[i] = vcl::random<vcl::Point3d>();
-            colors[i] = vcl::Color(
-                vcl::random<uint8_t>(),
-                vcl::random<uint8_t>(),
-                vcl::random<uint8_t>()
-            );
         }
 
         points->setVertices(positions);
-        points->setVertexColors(colors);
     }
+
+    std::vector<vcl::Color> colors(nPoints);
+    for (vcl::uint i = 0; i < nPoints; ++i) {
+        colors[i] = vcl::Color(
+            vcl::random<uint8_t>(),
+            vcl::random<uint8_t>(),
+            vcl::random<uint8_t>());
+    }
+    points->setVertexColors(colors);
 
     points->setSize(10);
     points->setColorSetting(vcl::Points::ColorSetting::PER_VERTEX);

--- a/examples/render/09-drawable-points/qt/main.cpp
+++ b/examples/render/09-drawable-points/qt/main.cpp
@@ -1,0 +1,104 @@
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+#include <vclib/bgfx/drawable/drawable_points.h>
+
+#include <vclib/qt/viewer_widget.h>
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QVBoxLayout>
+
+class ColorToUseComboBox : public QComboBox
+{
+public:
+    ColorToUseComboBox(QWidget* parent = nullptr) : QComboBox(parent)
+    {
+        addItems({"Per Vertex", "General"});
+    }
+};
+
+std::shared_ptr<vcl::DrawablePoints> getPoints(
+    std::shared_ptr<vcl::DrawableObjectVector> vec)
+{
+    std::shared_ptr<vcl::DrawablePoints> lines =
+        std::dynamic_pointer_cast<vcl::DrawablePoints>(vec->at(0));
+
+    return lines;
+}
+
+int main(int argc, char** argv)
+{
+    auto app = vcl::qt::qAppl(argc, argv);
+
+    QWidget w;
+
+    // add the viewer tw to the layout
+    QVBoxLayout* layout = new QVBoxLayout(&w);
+
+    ColorToUseComboBox* ccb = new ColorToUseComboBox(&w);
+    layout->addWidget(ccb);
+
+    QSlider* tslider = new QSlider();
+    tslider->setOrientation(Qt::Orientation::Horizontal);
+    tslider->setMinimum(1);
+    tslider->setMaximum(100);
+    tslider->setValue(5);
+    layout->addWidget(tslider);
+
+    vcl::qt::ViewerWidget* tw = new vcl::qt::ViewerWidget(&w);
+    layout->addWidget(tw);
+
+    const vcl::uint N_POINTS = 100;
+
+    std::shared_ptr<vcl::DrawableObjectVector> vec =
+        std::make_shared<vcl::DrawableObjectVector>();
+
+    //vec->pushBack(std::move(getDrawablePoints(N_POINTS)));
+
+    tw->setDrawableObjectVector(vec);
+    //tslider->setValue(getPoints(vec)->size());
+
+    QObject::connect(
+        ccb,
+        static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+        [=](int index) {
+            using ColorSetting = vcl::Points::ColorSetting;
+
+            std::cerr << "Color to use: " << index << std::endl;
+
+            //getPoints(vec)->setColorSetting((ColorSetting) index);
+            tw->update();
+        });
+
+    QObject::connect(tslider, &QSlider::valueChanged, [=](int value) {
+        std::cerr << "Size: " << value << std::endl;
+        //getPoints(vec)->setSize((float) value);
+        tw->update();
+    });
+
+    w.resize(1024, 768);
+
+    w.show();
+
+    return app.exec();
+}

--- a/vclib/render/include/vclib/bgfx/drawable/drawable_points.h
+++ b/vclib/render/include/vclib/bgfx/drawable/drawable_points.h
@@ -31,6 +31,14 @@
 
 namespace vcl {
 
+/**
+ * @brief A DrawableObject that renders a set of 3D points.
+ *
+ * This class wraps the `vcl::Points` primitive to be used within the VCLib
+ * rendering framework as a `DrawableObject`. It maintains a local CPU copy
+ * of the vertices, normals, and colors to support `DrawableObject` interfaces
+ * such as bounding box computation and cloning.
+ */
 class DrawablePoints: public DrawableObject, public Points
 {
     bool mVisible = true;
@@ -49,8 +57,14 @@ public:
     using Points::Shading;
     using Points::Shape;
 
+    /**
+     * @brief Default constructor. Creates an empty drawable point set.
+     */
     DrawablePoints() = default;
 
+    /**
+     * @brief Copy constructor. Creates a deep copy of the point set.
+     */
     DrawablePoints(const DrawablePoints& other) :
             DrawableObject(other),
             Points(other.mPositions, other.mNormals, other.mColors),
@@ -59,16 +73,25 @@ public:
     {
     }
 
+    /**
+     * @brief Move constructor.
+     */
     DrawablePoints(DrawablePoints&& other) { swap(other); }
 
     ~DrawablePoints() = default;
 
+    /**
+     * @brief Copy assignment operator.
+     */
     DrawablePoints& operator=(DrawablePoints other)
     {
         swap(other);
         return *this;
     }
 
+    /**
+     * @brief Swaps the contents of this object with another.
+     */
     void swap(DrawablePoints& other)
     {
         using std::swap;
@@ -82,6 +105,12 @@ public:
         swap(mColors, other.mColors);
     }
 
+    /**
+     * @brief Sets point positions from a range of 3D points and stores a local copy.
+     *
+     * @tparam R Range type satisfying Point3Concept.
+     * @param verts Range of 3D points.
+     */
     template<Range R>
     requires Point3Concept<std::ranges::range_value_t<R>>
     void setVertices(R&& verts)
@@ -90,6 +119,12 @@ public:
         mPositions.assign(std::ranges::begin(verts), std::ranges::end(verts));
     }
 
+    /**
+     * @brief Sets per-point normals from a range of 3D points and stores a local copy.
+     *
+     * @tparam R Range type satisfying Point3Concept.
+     * @param vertNormals Range of 3D points representing normals.
+     */
     template<Range R>
     requires Point3Concept<std::ranges::range_value_t<R>>
     void setVertexNormals(R&& vertNormals)
@@ -99,6 +134,12 @@ public:
             std::ranges::begin(vertNormals), std::ranges::end(vertNormals));
     }
 
+    /**
+     * @brief Sets per-point colors from a range of Colors and stores a local copy.
+     *
+     * @tparam R Range type satisfying ColorConcept.
+     * @param vertColors Range of Colors.
+     */
     template<Range R>
     requires ColorConcept<std::ranges::range_value_t<R>>
     void setVertexColors(R&& vertColors)

--- a/vclib/render/include/vclib/bgfx/drawable/drawable_points.h
+++ b/vclib/render/include/vclib/bgfx/drawable/drawable_points.h
@@ -43,6 +43,7 @@ public:
     using Points::ColorSetting;
     using Points::Shading;
     using Points::Shape;
+    using Points::size;
     using Points::setSize;
     using Points::setColorSetting;
     using Points::setShading;

--- a/vclib/render/include/vclib/bgfx/drawable/drawable_points.h
+++ b/vclib/render/include/vclib/bgfx/drawable/drawable_points.h
@@ -31,7 +31,7 @@
 
 namespace vcl {
 
-class DrawablePoints: public DrawableObject, private Points
+class DrawablePoints: public DrawableObject, public Points
 {
     bool mVisible = true;
 
@@ -39,16 +39,15 @@ class DrawablePoints: public DrawableObject, private Points
     std::vector<vcl::Point3d> mNormals;
     std::vector<vcl::Color>   mColors;
 
+    using Points::setVertices;
+    using Points::setVertexColors;
+    using Points::setVertexNormals;
+    using Points::draw;
+
 public:
     using Points::ColorSetting;
     using Points::Shading;
     using Points::Shape;
-    using Points::width;
-    using Points::setSize;
-    using Points::setColorSetting;
-    using Points::setShading;
-    using Points::setShape;
-    using Points::setGeneralColor;
 
     DrawablePoints() = default;
 

--- a/vclib/render/include/vclib/bgfx/drawable/drawable_points.h
+++ b/vclib/render/include/vclib/bgfx/drawable/drawable_points.h
@@ -43,7 +43,7 @@ public:
     using Points::ColorSetting;
     using Points::Shading;
     using Points::Shape;
-    using Points::size;
+    using Points::width;
     using Points::setSize;
     using Points::setColorSetting;
     using Points::setShading;

--- a/vclib/render/include/vclib/bgfx/drawable/drawable_points.h
+++ b/vclib/render/include/vclib/bgfx/drawable/drawable_points.h
@@ -1,0 +1,140 @@
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+#ifndef VCL_BGFX_DRAWABLE_DRAWABLE_POINTS_H
+#define VCL_BGFX_DRAWABLE_DRAWABLE_POINTS_H
+
+#include <vclib/bgfx/context.h>
+#include <vclib/bgfx/primitives/points.h>
+#include <vclib/render/drawable/drawable_object.h>
+
+#include <bgfx/bgfx.h>
+
+namespace vcl {
+
+class DrawablePoints: public DrawableObject, private Points
+{
+    bool mVisible = true;
+
+    std::vector<vcl::Point3d> mPositions;
+    std::vector<vcl::Point3d> mNormals;
+    std::vector<vcl::Color>   mColors;
+
+public:
+    using Points::ColorSetting;
+    using Points::Shading;
+    using Points::Shape;
+    using Points::setSize;
+    using Points::setColorSetting;
+    using Points::setShading;
+    using Points::setShape;
+    using Points::setGeneralColor;
+
+    DrawablePoints() = default;
+
+    DrawablePoints(const DrawablePoints& other) :
+            DrawableObject(other),
+            Points(other.mPositions, other.mNormals, other.mColors),
+            mVisible(other.mVisible), mPositions(other.mPositions),
+            mNormals(other.mNormals), mColors(other.mColors)
+    {
+    }
+
+    DrawablePoints(DrawablePoints&& other) { swap(other); }
+
+    ~DrawablePoints() = default;
+
+    DrawablePoints& operator=(DrawablePoints other)
+    {
+        swap(other);
+        return *this;
+    }
+
+    void swap(DrawablePoints& other)
+    {
+        using std::swap;
+        DrawableObject::swap(other);
+        swap(static_cast<Points&>(*this), static_cast<Points&>(other));
+
+        swap(mVisible, other.mVisible);
+
+        swap(mPositions, other.mPositions);
+        swap(mNormals, other.mNormals);
+        swap(mColors, other.mColors);
+    }
+
+    template<Range R>
+    requires Point3Concept<std::ranges::range_value_t<R>>
+    void setVertices(R&& verts)
+    {
+        Points::setVertices(verts);
+        mPositions.assign(std::ranges::begin(verts), std::ranges::end(verts));
+    }
+
+    template<Range R>
+    requires Point3Concept<std::ranges::range_value_t<R>>
+    void setVertexNormals(R&& vertNormals)
+    {
+        Points::setVertexNormals(vertNormals);
+        mNormals.assign(
+            std::ranges::begin(vertNormals), std::ranges::end(vertNormals));
+    }
+
+    template<Range R>
+    requires ColorConcept<std::ranges::range_value_t<R>>
+    void setVertexColors(R&& vertColors)
+    {
+        Points::setVertexColors(vertColors);
+        mColors.assign(
+            std::ranges::begin(vertColors), std::ranges::end(vertColors));
+    }
+
+    // DrawableObject interface
+
+    void draw(const DrawObjectSettings& settings) override
+    {
+        Points::draw(settings.viewId);
+    }
+
+    vcl::Box3d boundingBox() const override
+    {
+        return vcl::boundingBox(mPositions);
+    }
+
+    std::shared_ptr<DrawableObject> clone() const& override
+    {
+        return std::make_shared<DrawablePoints>(*this);
+    }
+
+    std::shared_ptr<DrawableObject> clone() && override
+    {
+        return std::make_shared<DrawablePoints>(std::move(*this));
+    }
+
+    bool isVisible() const override { return mVisible; }
+
+    void setVisibility(bool vis) override { mVisible = vis; }
+};
+
+} // namespace vcl
+
+#endif // VCL_BGFX_DRAWABLE_DRAWABLE_POINTS_H

--- a/vclib/render/include/vclib/bgfx/primitives/points.h
+++ b/vclib/render/include/vclib/bgfx/primitives/points.h
@@ -172,8 +172,11 @@ public:
     {
         mVertexCount = std::ranges::size(verts);
 
-        // Move to the nearest multiple of 2 to ensure padding of 4 floats
-        uint nv = mVertexCount + (mVertexCount % 2);
+        // Compute padding to ensure the buffer size is a multiple of 4 floats
+        // (16 bytes). This is required because the vertex shader reads the
+        // buffer as vec4 elements.
+        uint padding = (4 - (mVertexCount % 4)) % 4;
+        uint nv = mVertexCount + padding;
 
         VertexBuffer vertBuff;
         auto [buffer, releaseFn] =
@@ -215,10 +218,16 @@ public:
     {
         assert(std::ranges::size(vertNormals) == mVertexCount);
 
+        // Compute padding to ensure the buffer size is a multiple of 4 floats
+        // (16 bytes). This is required because the vertex shader reads the
+        // buffer as vec4 elements.
+        uint padding = (4 - (mVertexCount % 4)) % 4;
+        uint nv = mVertexCount + padding;
+
         VertexBuffer vNormsBuff;
 
         auto [buffer, releaseFn] =
-            Context::getAllocatedBufferAndReleaseFn<float>(mVertexCount * 3);
+            Context::getAllocatedBufferAndReleaseFn<float>(nv * 3);
 
         for (size_t i = 0; const auto& n : vertNormals) {
             buffer[i * 3 + 0] = n.x();
@@ -229,7 +238,7 @@ public:
 
         vNormsBuff.create(
             buffer,
-            mVertexCount,
+            nv,
             bgfx::Attrib::Normal,
             3,
             PrimitiveType::FLOAT,
@@ -251,10 +260,14 @@ public:
     {
         assert(std::ranges::size(vertColors) == mVertexCount);
 
+        // Compute padding to ensure the buffer size is a multiple of 16 bytes.
+        uint padding = (4 - (mVertexCount % 4)) % 4;
+        uint nv = mVertexCount + padding;
+
         VertexBuffer vColsBuff;
 
         auto [buffer, releaseFn] =
-            Context::getAllocatedBufferAndReleaseFn<uint>(mVertexCount);
+            Context::getAllocatedBufferAndReleaseFn<uint>(nv);
 
         for (uint i = 0; const auto& c : vertColors) {
             buffer[i] = c.abgr();
@@ -263,7 +276,7 @@ public:
 
         vColsBuff.create(
             buffer,
-            mVertexCount,
+            nv,
             bgfx::Attrib::Color0,
             4,
             PrimitiveType::UCHAR,

--- a/vclib/render/include/vclib/bgfx/primitives/points.h
+++ b/vclib/render/include/vclib/bgfx/primitives/points.h
@@ -73,7 +73,8 @@ private:
     OwnedOrRefBuffer<VertexBuffer> mVertexNormals;
     OwnedOrRefBuffer<VertexBuffer> mVertexColors;
 
-    mutable bool mIsValidityCheckNeeded = true;
+    mutable bool mIsUpdateProgramNeeded = true;
+    mutable bgfx::ProgramHandle mProgram = BGFX_INVALID_HANDLE;
 
 public:
     /**
@@ -193,6 +194,7 @@ public:
             PrimitiveType::FLOAT,
             releaseFn);
         mVertexPositions.setOwned(std::move(vertBuff));
+        mIsUpdateProgramNeeded = true;
     }
 
     /**
@@ -233,7 +235,7 @@ public:
             PrimitiveType::FLOAT,
             releaseFn);
         mVertexNormals.setOwned(std::move(vNormsBuff));
-        mIsValidityCheckNeeded = true;
+        mIsUpdateProgramNeeded = true;
     }
 
     /**
@@ -268,7 +270,7 @@ public:
             true,
             releaseFn);
         mVertexColors.setOwned(std::move(vColsBuff));
-        mIsValidityCheckNeeded = true;
+        mIsUpdateProgramNeeded = true;
     }
 
     void setVertices(const uint vertexCount, const VertexBuffer& verts);
@@ -293,7 +295,7 @@ public:
     void setColorSetting(ColorSetting colorToUse)
     {
         mColorToUse            = colorToUse;
-        mIsValidityCheckNeeded = true;
+        mIsUpdateProgramNeeded = true;
     }
 
      /**
@@ -305,7 +307,7 @@ public:
     void setShading(Shading shading)
     {
         mShading               = shading;
-        mIsValidityCheckNeeded = true;
+        mIsUpdateProgramNeeded = true;
     }
 
     /**
@@ -313,7 +315,11 @@ public:
      *
      * @param[in] shape: The sprite shape (SQUARE or CIRCLE).
      */
-    void setShape(Shape shape) { mShape = shape; }
+    void setShape(Shape shape)
+    {
+        mShape                 = shape;
+        mIsUpdateProgramNeeded = true;
+    }
 
     /**
      * @brief Sets the general (uniform) color used when color mode is GENERAL.
@@ -328,7 +334,7 @@ public:
     void draw(bgfx::ViewId viewId) const;
 
 private:
-    void validityCheck() const;
+    void checkAndUpdateProgram() const;
     bgfx::ProgramHandle pointsProgramSelector() const;
 
     static constexpr uint POINTS_POSITIONS_STAGE = 0;

--- a/vclib/render/include/vclib/bgfx/primitives/points.h
+++ b/vclib/render/include/vclib/bgfx/primitives/points.h
@@ -28,7 +28,7 @@
 namespace vcl {
 
 /**
- * @brief Renders a set of 3D points in world space as point sprites (squares
+ * @brief Renders a set of 3D points in world space as point splats (squares
  * or circles).
  *
  * Each point is positioned using its 3D coordinates and projected through the
@@ -53,11 +53,11 @@ public:
     };
 
     /**
-     * @brief Specifies the visual shape of each point sprite.
+     * @brief Specifies the visual shape of each point splat.
      */
     enum class Shape {
-        SQUARE, ///< Square sprites (axis-aligned quads in screen space).
-        CIRCLE  ///< Circular sprites (disk-shaped in screen space).
+        SQUARE, ///< Square splats (axis-aligned quads in screen space).
+        CIRCLE  ///< Circular splats (disk-shaped in screen space).
     };
 
 private:
@@ -280,9 +280,9 @@ public:
     void setVertexColors(const VertexBuffer& vertColors);
 
     /**
-     * @brief Sets the size of point sprites.
+     * @brief Sets the size of point splats.
      *
-     * @param[in] size: The point sprite size.
+     * @param[in] size: The point splat size.
      */
     void setSize(float size) { mWidth = size; }
 
@@ -311,9 +311,9 @@ public:
     }
 
     /**
-     * @brief Sets the visual shape of each point sprite.
+     * @brief Sets the visual shape of each point splat.
      *
-     * @param[in] shape: The sprite shape (SQUARE or CIRCLE).
+     * @param[in] shape: The splat shape (SQUARE or CIRCLE).
      */
     void setShape(Shape shape)
     {

--- a/vclib/render/include/vclib/bgfx/primitives/points.h
+++ b/vclib/render/include/vclib/bgfx/primitives/points.h
@@ -73,6 +73,8 @@ private:
     OwnedOrRefBuffer<VertexBuffer> mVertexNormals;
     OwnedOrRefBuffer<VertexBuffer> mVertexColors;
 
+    mutable bool mIsValidityCheckNeeded = true;
+
 public:
     /**
      * @brief Default constructor — creates an empty point set with no points.
@@ -231,6 +233,7 @@ public:
             PrimitiveType::FLOAT,
             releaseFn);
         mVertexNormals.setOwned(std::move(vNormsBuff));
+        mIsValidityCheckNeeded = true;
     }
 
     /**
@@ -265,6 +268,7 @@ public:
             true,
             releaseFn);
         mVertexColors.setOwned(std::move(vColsBuff));
+        mIsValidityCheckNeeded = true;
     }
 
     void setVertices(const uint vertexCount, const VertexBuffer& verts);
@@ -286,7 +290,11 @@ public:
      * @param[in] colorToUse: Whether to use per-point colors or a general
      * uniform color.
      */
-    void setColorSetting(ColorSetting colorToUse) { mColorToUse = colorToUse; }
+    void setColorSetting(ColorSetting colorToUse)
+    {
+        mColorToUse            = colorToUse;
+        mIsValidityCheckNeeded = true;
+    }
 
      /**
      * @brief Sets the shading mode for point rendering.
@@ -294,7 +302,11 @@ public:
      * @param[in] shading: Whether to apply no shading or compute lighting per
      * vertex using normals (if provided).
      */
-    void setShading(Shading shading) { mShading = shading; }
+    void setShading(Shading shading)
+    {
+        mShading               = shading;
+        mIsValidityCheckNeeded = true;
+    }
 
     /**
      * @brief Sets the visual shape of each point sprite.

--- a/vclib/render/include/vclib/bgfx/primitives/points.h
+++ b/vclib/render/include/vclib/bgfx/primitives/points.h
@@ -329,6 +329,7 @@ public:
 
 private:
     void validityCheck() const;
+    bgfx::ProgramHandle pointsProgramSelector() const;
 
     static constexpr uint POINTS_POSITIONS_STAGE = 0;
     static constexpr uint POINTS_NORMALS_STAGE   = 1;

--- a/vclib/render/include/vclib/bgfx/primitives/points.h
+++ b/vclib/render/include/vclib/bgfx/primitives/points.h
@@ -47,6 +47,11 @@ public:
         GENERAL     ///< All points use a single general color.
     };
 
+    enum class Shading {
+        NONE,       ///< No shading applied to points.
+        PER_VERTEX  ///< Lighting computed using vertex normals (if provided).
+    };
+
     /**
      * @brief Specifies the visual shape of each point sprite.
      */
@@ -60,10 +65,12 @@ private:
 
     float        mSize         = 1.0f;
     ColorSetting mColorToUse   = ColorSetting::GENERAL;
+    Shading      mShading      = Shading::NONE;
     Shape        mShape        = Shape::SQUARE;
     Color        mGeneralColor = Color::Black;
 
     OwnedOrRefBuffer<VertexBuffer> mVertexPositions;
+    OwnedOrRefBuffer<VertexBuffer> mVertexNormals;
     OwnedOrRefBuffer<VertexBuffer> mVertexColors;
 
 public:
@@ -78,6 +85,7 @@ public:
      *
      * @param[in] verts: Range of elements convertible to Point3 (must
      * provide x(), y(), z()). Each element contributes one world-space point.
+     * @param[in] vertNormals: Optional range of elements convertible to Point3.
      * @param[in] vertColors: Optional range of Color elements. If non-empty,
      * per-point colors are enabled; the size must match vertCoords. Default is
      * empty (falls back to general color).
@@ -85,32 +93,24 @@ public:
      * @note This constructor creates an owned buffer copy of the input data.
      * The original ranges are not referenced after construction.
      */
-    template<Range RV, Range RC>
+    template<Range RV, Range RN, Range RC>
     requires Point3Concept<std::ranges::range_value_t<RV>> &&
+             Point3Concept<std::ranges::range_value_t<RN>> &&
              ColorConcept<std::ranges::range_value_t<RC>>
-    Points(RV&& verts, RC&& vertColors = std::vector<Color>())
+    Points(
+        RV&& verts,
+        RN&& vertNormals = std::vector<Point3d>(),
+        RC&& vertColors  = std::vector<Color>())
     {
         setVertices(verts);
+        if (!vertNormals.empty()) {
+            setVertexNormals(vertNormals);
+        }
         if (!vertColors.empty()) {
             setVertexColors(vertColors);
         }
     }
 
-    /**
-     * @brief Constructs a point set by referencing existing VertexBuffers.
-     *
-     * @param[in] vertexCount: Number of points (length of verts).
-     * @param[in] verts: VertexBuffer containing point positions.
-     * Expected layout: an array of `float` with 3 components per point (x, y,
-     * z), stored as consecutive floats: [x0, y0, z0, x1, y1, z1, ..., xn-1,
-     * yn-1, zn-1]. The buffer must be created for compute access and must
-     * remain valid for the lifetime of this object.
-     * @param[in] vertColors: Optional VertexBuffer containing per-point colors.
-     * Expected layout: an array of `uint` with 4 channels per color in ABGR
-     * order (A, B, G, R packed as a single 32-bit integer). The buffer must be
-     * created for compute access and must remain valid for the lifetime of
-     * this object.
-     */
     Points(
         const uint          vertexCount,
         const VertexBuffer& verts,
@@ -159,11 +159,51 @@ public:
     }
 
     /**
+     * @brief Sets per-point normals from a range of 3D points.
+     *
+     * @tparam R: Range whose value type satisfies Point3Concept (must provide
+     * x(), y(), z()).
+     * @param[in] vertNormals: Range of 3D points representing normals. Each
+     * element is read as a normal vector (x, y, z) for the corresponding point.
+     * The size must match vertexCount().
+     *
+     * @note This creates an owned buffer copy. The original range is not
+     * referenced.
+     */
+    template<Range R>
+    requires Point3Concept<std::ranges::range_value_t<R>>
+    void setVertexNormals(R&& vertNormals)
+    {
+        assert(std::ranges::size(vertNormals) == mVertexCount);
+
+        VertexBuffer vNormsBuff;
+
+        auto [buffer, releaseFn] =
+            Context::getAllocatedBufferAndReleaseFn<float>(mVertexCount * 3);
+
+        for (size_t i = 0; const auto& n : vertNormals) {
+            buffer[i * 3 + 0] = n.x();
+            buffer[i * 3 + 1] = n.y();
+            buffer[i * 3 + 2] = n.z();
+            ++i;
+        }
+
+        vNormsBuff.create(
+            buffer,
+            mVertexCount,
+            bgfx::Attrib::Normal,
+            3,
+            PrimitiveType::FLOAT,
+            releaseFn);
+        mVertexNormals.setOwned(std::move(vNormsBuff));
+    }
+
+    /**
      * @brief Sets per-point colors from a range of Color elements.
      *
      * @tparam R: Range whose value type satisfies ColorConcept.
      * @param[in] vertColors: Range of Color objects. Must have exactly
-     * the pointsCount() size. Each color is converted to ABGR format (uint).
+     * the vertexCount() size. Each color is converted to ABGR format (uint).
      */
     template<Range R>
     requires ColorConcept<std::ranges::range_value_t<R>>
@@ -192,27 +232,10 @@ public:
         mVertexColors.setOwned(std::move(vColsBuff));
     }
 
-    /**
-     * @brief Sets point positions by referencing an existing VertexBuffer.
-     *
-     * @param[in] vertexCount: Number of points (length of verts).
-     * @param[in] verts: VertexBuffer containing point positions.
-     * Expected layout: an array of `float` with 3 components per point (x, y,
-     * z), stored as consecutive floats: [x0, y0, z0, x1, y1, z1, ..., xn-1,
-     * yn-1, zn-1]. The buffer must be created for compute access and must
-     * remain valid for the lifetime of this object.
-     */
     void setVertices(const uint vertexCount, const VertexBuffer& verts);
 
-    /**
-     * @brief Sets per-point colors by referencing an existing VertexBuffer.
-     *
-     * @param[in] vertColors: VertexBuffer containing per-point colors.
-     * Expected layout: an array of `uint` with 4 channels per color in
-     * ABGR order (A, B, G, R packed as a single 32-bit integer). The buffer
-     * must be created for compute access and must remain valid for the
-     * lifetime of this object.
-     */
+    void setVertexNormals(const VertexBuffer& vertNormals);
+
     void setVertexColors(const VertexBuffer& vertColors);
 
     /**
@@ -247,21 +270,12 @@ public:
         mGeneralColor = generalColor;
     }
 
-    /**
-     * @brief Draws the point sprites in world space on the specified view.
-     *
-     * Renders all 3D points as screen-space splats using programmable vertex
-     * pulling. Points are positioned through the standard camera projection,
-     * and each point is expanded into a quad procedurally depending on the
-     * configured Shape setting.
-     *
-     * @param[in] viewId: The bgfx view ID to submit the rendering commands to.
-     */
     void draw(bgfx::ViewId viewId) const;
 
 private:
     static constexpr uint POINTS_POSITIONS_STAGE = 0;
-    static constexpr uint POINTS_COLORS_STAGE    = 1;
+    static constexpr uint POINTS_NORMALS_STAGE   = 1;
+    static constexpr uint POINTS_COLORS_STAGE    = 2;
 };
 
 } // namespace vcl

--- a/vclib/render/include/vclib/bgfx/primitives/points.h
+++ b/vclib/render/include/vclib/bgfx/primitives/points.h
@@ -253,12 +253,20 @@ public:
      */
     void setColorSetting(ColorSetting colorToUse) { mColorToUse = colorToUse; }
 
+     /**
+     * @brief Sets the shading mode for point rendering.
+     *
+     * @param[in] shading: Whether to apply no shading or compute lighting per
+     * vertex using normals (if provided).
+     */
+    void setShading(Shading shading) { mShading = shading; }
+
     /**
      * @brief Sets the visual shape of each point sprite.
      *
      * @param[in] shape: The sprite shape (SQUARE or CIRCLE).
      */
-    void setShapeSetting(Shape shape) { mShape = shape; }
+    void setShape(Shape shape) { mShape = shape; }
 
     /**
      * @brief Sets the general (uniform) color used when color mode is GENERAL.

--- a/vclib/render/include/vclib/bgfx/primitives/points.h
+++ b/vclib/render/include/vclib/bgfx/primitives/points.h
@@ -117,6 +117,13 @@ public:
         const VertexBuffer& vertColors = NULL_VERTEX_BUFFER);
 
     /**
+     * @brief Returns the render size of point sprites.
+     *
+     * @return The size of each point sprite in pixels.
+     */
+    float size() const { return mSize; }
+
+    /**
      * @brief Sets point positions from a range of 3D points.
      *
      * @tparam R: Range whose value type satisfies Point3Concept (must provide

--- a/vclib/render/include/vclib/bgfx/primitives/points.h
+++ b/vclib/render/include/vclib/bgfx/primitives/points.h
@@ -316,6 +316,8 @@ public:
     void draw(bgfx::ViewId viewId) const;
 
 private:
+    void validityCheck() const;
+
     static constexpr uint POINTS_POSITIONS_STAGE = 0;
     static constexpr uint POINTS_NORMALS_STAGE   = 1;
     static constexpr uint POINTS_COLORS_STAGE    = 2;

--- a/vclib/render/include/vclib/bgfx/primitives/points.h
+++ b/vclib/render/include/vclib/bgfx/primitives/points.h
@@ -63,7 +63,7 @@ public:
 private:
     uint mVertexCount = 0;
 
-    float        mSize         = 1.0f;
+    float        mWidth        = 1.0f;
     ColorSetting mColorToUse   = ColorSetting::GENERAL;
     Shading      mShading      = Shading::NONE;
     Shape        mShape        = Shape::SQUARE;
@@ -117,11 +117,39 @@ public:
         const VertexBuffer& vertColors = NULL_VERTEX_BUFFER);
 
     /**
-     * @brief Returns the render size of point sprites.
+     * @brief Returns the width of point splats.
      *
-     * @return The size of each point sprite in pixels.
+     * @return The width of the point splats in pixels.
      */
-    float size() const { return mSize; }
+    float width() const { return mWidth; }
+
+    /**
+     * @brief Returns whether the point set has valid vertex positions.
+     *
+     * @return True if vertex positions are valid; false otherwise.
+     */
+    bool hasPositions() const { return mVertexPositions.isValid(); }
+
+    /**
+     * @brief Returns whether the point set has valid vertex normals.
+     *
+     * @return True if vertex normals are valid; false otherwise.
+     */
+    bool hasNormals() const { return mVertexNormals.isValid(); }
+
+    /**
+     * @brief Returns whether the point set has valid vertex colors.
+     *
+     * @return True if vertex colors are valid; false otherwise.
+     */
+    bool hasColors() const { return mVertexColors.isValid(); }
+
+    /**
+     * @brief Returns the number of points in the set.
+     *
+     * @return The number of points (vertices) in the set.
+     */
+    uint vertexCount() const { return mVertexCount; }
 
     /**
      * @brief Sets point positions from a range of 3D points.
@@ -250,7 +278,7 @@ public:
      *
      * @param[in] size: The point sprite size.
      */
-    void setSize(float size) { mSize = size; }
+    void setSize(float size) { mWidth = size; }
 
     /**
      * @brief Sets the color mode for point rendering.

--- a/vclib/render/include/vclib/bgfx/primitives/points.h
+++ b/vclib/render/include/vclib/bgfx/primitives/points.h
@@ -1,0 +1,269 @@
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+#ifndef VCL_BGFX_PRIMITIVES_POINTS_H
+#define VCL_BGFX_PRIMITIVES_POINTS_H
+
+#include <vclib/bgfx/buffers.h>
+
+namespace vcl {
+
+/**
+ * @brief Renders a set of 3D points in world space as point sprites (squares
+ * or circles).
+ *
+ * Each point is positioned using its 3D coordinates and projected through the
+ * standard camera pipeline.
+ */
+class Points
+{
+    inline static const VertexBuffer NULL_VERTEX_BUFFER;
+
+public:
+    /**
+     * @brief Specifies how point colors are determined during rendering.
+     */
+    enum class ColorSetting {
+        PER_VERTEX, ///< Each point uses color from per-vertex color buffer.
+        GENERAL     ///< All points use a single general color.
+    };
+
+    /**
+     * @brief Specifies the visual shape of each point sprite.
+     */
+    enum class Shape {
+        SQUARE, ///< Square sprites (axis-aligned quads in screen space).
+        CIRCLE  ///< Circular sprites (disk-shaped in screen space).
+    };
+
+private:
+    uint mVertexCount = 0;
+
+    float        mSize         = 1.0f;
+    ColorSetting mColorToUse   = ColorSetting::GENERAL;
+    Shape        mShape        = Shape::SQUARE;
+    Color        mGeneralColor = Color::Black;
+
+    OwnedOrRefBuffer<VertexBuffer> mVertexPositions;
+    OwnedOrRefBuffer<VertexBuffer> mVertexColors;
+
+public:
+    /**
+     * @brief Default constructor — creates an empty point set with no points.
+     */
+    Points() = default;
+
+    /**
+     * @brief Constructs a point set from ranges of 3D coordinates and
+     * per-point colors.
+     *
+     * @param[in] verts: Range of elements convertible to Point3 (must
+     * provide x(), y(), z()). Each element contributes one world-space point.
+     * @param[in] vertColors: Optional range of Color elements. If non-empty,
+     * per-point colors are enabled; the size must match vertCoords. Default is
+     * empty (falls back to general color).
+     *
+     * @note This constructor creates an owned buffer copy of the input data.
+     * The original ranges are not referenced after construction.
+     */
+    template<Range RV, Range RC>
+    requires Point3Concept<std::ranges::range_value_t<RV>> &&
+             ColorConcept<std::ranges::range_value_t<RC>>
+    Points(RV&& verts, RC&& vertColors = std::vector<Color>())
+    {
+        setVertices(verts);
+        if (!vertColors.empty()) {
+            setVertexColors(vertColors);
+        }
+    }
+
+    /**
+     * @brief Constructs a point set by referencing existing VertexBuffers.
+     *
+     * @param[in] vertexCount: Number of points (length of verts).
+     * @param[in] verts: VertexBuffer containing point positions.
+     * Expected layout: an array of `float` with 3 components per point (x, y,
+     * z), stored as consecutive floats: [x0, y0, z0, x1, y1, z1, ..., xn-1,
+     * yn-1, zn-1]. The buffer must be created for compute access and must
+     * remain valid for the lifetime of this object.
+     * @param[in] vertColors: Optional VertexBuffer containing per-point colors.
+     * Expected layout: an array of `uint` with 4 channels per color in ABGR
+     * order (A, B, G, R packed as a single 32-bit integer). The buffer must be
+     * created for compute access and must remain valid for the lifetime of
+     * this object.
+     */
+    Points(
+        const uint          vertexCount,
+        const VertexBuffer& verts,
+        const VertexBuffer& vertColors = NULL_VERTEX_BUFFER);
+
+    /**
+     * @brief Sets point positions from a range of 3D points.
+     *
+     * @tparam R: Range whose value type satisfies Point3Concept (must provide
+     * x(), y(), z()).
+     * @param[in] verts: Range of 3D points. Each element is read as a
+     * world-space coordinate (x, y, z). The size determines the number of
+     * rendered points.
+     *
+     * @note This creates an owned buffer copy. The original range is not
+     * referenced.
+     */
+    template<Range R>
+    requires Point3Concept<std::ranges::range_value_t<R>>
+    void setVertices(R&& verts)
+    {
+        mVertexCount = std::ranges::size(verts);
+
+        // Move to the nearest multiple of 2 to ensure padding of 4 floats
+        uint nv = mVertexCount + (mVertexCount % 2);
+
+        VertexBuffer vertBuff;
+        auto [buffer, releaseFn] =
+            Context::getAllocatedBufferAndReleaseFn<float>(nv * 3);
+
+        for (size_t i = 0; const auto& v : verts) {
+            buffer[i * 3 + 0] = v.x();
+            buffer[i * 3 + 1] = v.y();
+            buffer[i * 3 + 2] = v.z();
+            ++i;
+        }
+
+        vertBuff.create(
+            buffer,
+            nv,
+            bgfx::Attrib::Position,
+            3,
+            PrimitiveType::FLOAT,
+            releaseFn);
+        mVertexPositions.setOwned(std::move(vertBuff));
+    }
+
+    /**
+     * @brief Sets per-point colors from a range of Color elements.
+     *
+     * @tparam R: Range whose value type satisfies ColorConcept.
+     * @param[in] vertColors: Range of Color objects. Must have exactly
+     * the pointsCount() size. Each color is converted to ABGR format (uint).
+     */
+    template<Range R>
+    requires ColorConcept<std::ranges::range_value_t<R>>
+    void setVertexColors(R&& vertColors)
+    {
+        assert(std::ranges::size(vertColors) == mVertexCount);
+
+        VertexBuffer vColsBuff;
+
+        auto [buffer, releaseFn] =
+            Context::getAllocatedBufferAndReleaseFn<uint>(mVertexCount);
+
+        for (uint i = 0; const auto& c : vertColors) {
+            buffer[i] = c.abgr();
+            ++i;
+        }
+
+        vColsBuff.create(
+            buffer,
+            mVertexCount,
+            bgfx::Attrib::Color0,
+            4,
+            PrimitiveType::UCHAR,
+            true,
+            releaseFn);
+        mVertexColors.setOwned(std::move(vColsBuff));
+    }
+
+    /**
+     * @brief Sets point positions by referencing an existing VertexBuffer.
+     *
+     * @param[in] vertexCount: Number of points (length of verts).
+     * @param[in] verts: VertexBuffer containing point positions.
+     * Expected layout: an array of `float` with 3 components per point (x, y,
+     * z), stored as consecutive floats: [x0, y0, z0, x1, y1, z1, ..., xn-1,
+     * yn-1, zn-1]. The buffer must be created for compute access and must
+     * remain valid for the lifetime of this object.
+     */
+    void setVertices(const uint vertexCount, const VertexBuffer& verts);
+
+    /**
+     * @brief Sets per-point colors by referencing an existing VertexBuffer.
+     *
+     * @param[in] vertColors: VertexBuffer containing per-point colors.
+     * Expected layout: an array of `uint` with 4 channels per color in
+     * ABGR order (A, B, G, R packed as a single 32-bit integer). The buffer
+     * must be created for compute access and must remain valid for the
+     * lifetime of this object.
+     */
+    void setVertexColors(const VertexBuffer& vertColors);
+
+    /**
+     * @brief Sets the size of point sprites.
+     *
+     * @param[in] size: The point sprite size.
+     */
+    void setSize(float size) { mSize = size; }
+
+    /**
+     * @brief Sets the color mode for point rendering.
+     *
+     * @param[in] colorToUse: Whether to use per-point colors or a general
+     * uniform color.
+     */
+    void setColorSetting(ColorSetting colorToUse) { mColorToUse = colorToUse; }
+
+    /**
+     * @brief Sets the visual shape of each point sprite.
+     *
+     * @param[in] shape: The sprite shape (SQUARE or CIRCLE).
+     */
+    void setShapeSetting(Shape shape) { mShape = shape; }
+
+    /**
+     * @brief Sets the general (uniform) color used when color mode is GENERAL.
+     *
+     * @param[in] generalColor: The fallback color for all points.
+     */
+    void setGeneralColor(const Color& generalColor)
+    {
+        mGeneralColor = generalColor;
+    }
+
+    /**
+     * @brief Draws the point sprites in world space on the specified view.
+     *
+     * Renders all 3D points as screen-space splats using programmable vertex
+     * pulling. Points are positioned through the standard camera projection,
+     * and each point is expanded into a quad procedurally depending on the
+     * configured Shape setting.
+     *
+     * @param[in] viewId: The bgfx view ID to submit the rendering commands to.
+     */
+    void draw(bgfx::ViewId viewId) const;
+
+private:
+    static constexpr uint POINTS_POSITIONS_STAGE = 0;
+    static constexpr uint POINTS_COLORS_STAGE    = 1;
+};
+
+} // namespace vcl
+
+#endif // VCL_BGFX_PRIMITIVES_POINTS_H

--- a/vclib/render/include/vclib/bgfx/primitives/uniforms/points_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/primitives/uniforms/points_uniforms.h
@@ -1,0 +1,72 @@
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+#ifndef VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_H
+#define VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_H
+
+#include <vclib/bgfx/uniform.h>
+#include <vclib/space/core.h>
+
+#include <array>
+#include <bit>
+
+namespace vcl {
+
+class PointsUniforms
+{
+    inline static std::array<float, 4> sPointsSettings;
+    inline static Uniform              sPointsSettingsUniform;
+
+public:
+    PointsUniforms() = delete;
+
+    static void setColorSetting(uint c)
+    {
+        sPointsSettings[0] = std::bit_cast<float>(c);
+    }
+
+    static void setShape(uint s)
+    {
+        sPointsSettings[1] = std::bit_cast<float>(s);
+    }
+
+    static void setSize(float size) { sPointsSettings[2] = size; }
+
+    static void setGeneralColor(const vcl::Color& color)
+    {
+        sPointsSettings[3] = std::bit_cast<float>(color.abgr());
+    }
+
+    static void bind()
+    {
+        // Lazy initialization to avoid creating uniforms before bgfx is
+        // initialized.
+        if (!sPointsSettingsUniform.isValid())
+            sPointsSettingsUniform =
+                Uniform("u_pointsSettings", bgfx::UniformType::Vec4);
+        sPointsSettingsUniform.bind(sPointsSettings.data());
+    }
+};
+
+} // namespace vcl
+
+#endif // VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_H

--- a/vclib/render/include/vclib/bgfx/primitives/uniforms/points_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/primitives/uniforms/points_uniforms.h
@@ -71,7 +71,7 @@ public:
         sPointsSettings[0] = std::bit_cast<float>(bs.underlying());
     }
 
-    static void setSize(float size) { sPointsSettings[1] = size; }
+    static void setWidth(float width) { sPointsSettings[1] = width; }
 
     static void setGeneralColor(const vcl::Color& color)
     {

--- a/vclib/render/include/vclib/bgfx/primitives/uniforms/points_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/primitives/uniforms/points_uniforms.h
@@ -31,6 +31,13 @@
 
 namespace vcl {
 
+/**
+ * @brief Manages the uniform variables required by the Points shaders.
+ *
+ * This utility class is responsible for packing points rendering settings
+ * (such as width and general color) into a vec4 uniform and binding it
+ * to the bgfx rendering context.
+ */
 class PointsUniforms
 {
     // .x = point width in pixels
@@ -43,13 +50,26 @@ class PointsUniforms
 public:
     PointsUniforms() = delete;
 
+    /**
+     * @brief Sets the width of the points.
+     * @param width The point width in pixels.
+     */
     static void setWidth(float width) { sPointsSettings[0] = width; }
 
+    /**
+     * @brief Sets the general color for points.
+     * @param color The uniform color to apply when per-vertex colors are not used.
+     */
     static void setGeneralColor(const vcl::Color& color)
     {
         sPointsSettings[1] = std::bit_cast<float>(color.abgr());
     }
 
+    /**
+     * @brief Binds the uniform to the current bgfx context.
+     *
+     * Lazily initializes the bgfx uniform handle if it hasn't been created yet.
+     */
     static void bind()
     {
         // Lazy initialization to avoid creating uniforms before bgfx is

--- a/vclib/render/include/vclib/bgfx/primitives/uniforms/points_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/primitives/uniforms/points_uniforms.h
@@ -33,7 +33,12 @@ namespace vcl {
 
 class PointsUniforms
 {
-    inline static std::array<float, 4> sPointsSettings;
+    inline static std::array<float, 4> sPointsSettings = {
+        std::bit_cast<float>(0), // packed bit settings (color, shading, shape)
+        1.0f,                    // size
+        std::bit_cast<float>(0),  // general color (ABGR)
+        0.f // unused
+    };
     inline static Uniform              sPointsSettingsUniform;
 
 public:
@@ -41,24 +46,36 @@ public:
 
     static void setColorSetting(uint c)
     {
-        sPointsSettings[0] = std::bit_cast<float>(c);
+        BitSet<uint> bs;
+        bs.setUnderlying(std::bit_cast<uint>(sPointsSettings[0]));
+        // if true, per vertex color, otherwise general
+        bs.at(0) = c == 0u;
+        sPointsSettings[0] = std::bit_cast<float>(bs.underlying());
     }
 
     static void setShading(uint s)
     {
-        // TODO
+        BitSet<uint> bs;
+        bs.setUnderlying(std::bit_cast<uint>(sPointsSettings[0]));
+        // if true, none, otherwise per vertex
+        bs.at(1) = s == 0u;
+        sPointsSettings[0] = std::bit_cast<float>(bs.underlying());
     }
 
     static void setShape(uint s)
     {
-        sPointsSettings[1] = std::bit_cast<float>(s);
+        BitSet<uint> bs;
+        bs.setUnderlying(std::bit_cast<uint>(sPointsSettings[0]));
+        // if true, square, otherwise circle
+        bs.at(2) = s == 0u;
+        sPointsSettings[0] = std::bit_cast<float>(bs.underlying());
     }
 
-    static void setSize(float size) { sPointsSettings[2] = size; }
+    static void setSize(float size) { sPointsSettings[1] = size; }
 
     static void setGeneralColor(const vcl::Color& color)
     {
-        sPointsSettings[3] = std::bit_cast<float>(color.abgr());
+        sPointsSettings[2] = std::bit_cast<float>(color.abgr());
     }
 
     static void bind()

--- a/vclib/render/include/vclib/bgfx/primitives/uniforms/points_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/primitives/uniforms/points_uniforms.h
@@ -44,6 +44,11 @@ public:
         sPointsSettings[0] = std::bit_cast<float>(c);
     }
 
+    static void setShading(uint s)
+    {
+        // TODO
+    }
+
     static void setShape(uint s)
     {
         sPointsSettings[1] = std::bit_cast<float>(s);

--- a/vclib/render/include/vclib/bgfx/primitives/uniforms/points_uniforms.h
+++ b/vclib/render/include/vclib/bgfx/primitives/uniforms/points_uniforms.h
@@ -33,49 +33,21 @@ namespace vcl {
 
 class PointsUniforms
 {
-    inline static std::array<float, 4> sPointsSettings = {
-        std::bit_cast<float>(0), // packed bit settings (color, shading, shape)
-        1.0f,                    // size
-        std::bit_cast<float>(0),  // general color (ABGR)
-        0.f // unused
-    };
+    // .x = point width in pixels
+    // .y = general color
+    // .z = unused
+    // .w = unused
+    inline static std::array<float, 4> sPointsSettings = {1.0f, 0.0f, 0.0f, 0.0f};
     inline static Uniform              sPointsSettingsUniform;
 
 public:
     PointsUniforms() = delete;
 
-    static void setColorSetting(uint c)
-    {
-        BitSet<uint> bs;
-        bs.setUnderlying(std::bit_cast<uint>(sPointsSettings[0]));
-        // if true, per vertex color, otherwise general
-        bs.at(0) = c == 0u;
-        sPointsSettings[0] = std::bit_cast<float>(bs.underlying());
-    }
-
-    static void setShading(uint s)
-    {
-        BitSet<uint> bs;
-        bs.setUnderlying(std::bit_cast<uint>(sPointsSettings[0]));
-        // if true, none, otherwise per vertex
-        bs.at(1) = s == 0u;
-        sPointsSettings[0] = std::bit_cast<float>(bs.underlying());
-    }
-
-    static void setShape(uint s)
-    {
-        BitSet<uint> bs;
-        bs.setUnderlying(std::bit_cast<uint>(sPointsSettings[0]));
-        // if true, square, otherwise circle
-        bs.at(2) = s == 0u;
-        sPointsSettings[0] = std::bit_cast<float>(bs.underlying());
-    }
-
-    static void setWidth(float width) { sPointsSettings[1] = width; }
+    static void setWidth(float width) { sPointsSettings[0] = width; }
 
     static void setGeneralColor(const vcl::Color& color)
     {
-        sPointsSettings[2] = std::bit_cast<float>(color.abgr());
+        sPointsSettings[1] = std::bit_cast<float>(color.abgr());
     }
 
     static void bind()

--- a/vclib/render/include/vclib/bgfx/screenspace/primitives/screenspace_points.h
+++ b/vclib/render/include/vclib/bgfx/screenspace/primitives/screenspace_points.h
@@ -184,10 +184,14 @@ public:
     {
         assert(std::ranges::size(vertColors) == mVertexCount);
 
+        // Compute padding to ensure the buffer size is a multiple of 16 bytes.
+        uint padding = (4 - (mVertexCount % 4)) % 4;
+        uint nv = mVertexCount + padding;
+
         VertexBuffer vColsBuff;
 
         auto [buffer, releaseFn] =
-            Context::getAllocatedBufferAndReleaseFn<uint>(mVertexCount);
+            Context::getAllocatedBufferAndReleaseFn<uint>(nv);
 
         for (uint i = 0; const auto& c : vertColors) {
             buffer[i] = c.abgr();
@@ -196,7 +200,7 @@ public:
 
         vColsBuff.create(
             buffer,
-            mVertexCount,
+            nv,
             bgfx::Attrib::Color0,
             4,
             PrimitiveType::UCHAR,

--- a/vclib/render/include/vclib/bgfx/screenspace/primitives/screenspace_points.h
+++ b/vclib/render/include/vclib/bgfx/screenspace/primitives/screenspace_points.h
@@ -103,6 +103,34 @@ public:
         const VertexBuffer& vertColors = NULL_VERTEX_BUFFER);
 
     /**
+     * @brief Returns the width of point splats.
+     *
+     * @return The width of the point splats in pixels.
+     */
+    float width() const { return mWidth; }
+
+    /**
+     * @brief Returns whether the point set has valid vertex positions.
+     *
+     * @return True if vertex positions are valid; false otherwise.
+     */
+    bool hasPositions() const { return mVertexPositions.isValid(); }
+
+    /**
+     * @brief Returns whether the point set has valid vertex colors.
+     *
+     * @return True if vertex colors are valid; false otherwise.
+     */
+    bool hasColors() const { return mVertexColors.isValid(); }
+
+    /**
+     * @brief Returns the number of points in the set.
+     *
+     * @return The number of points (vertices) in the set.
+     */
+    uint vertexCount() const { return mVertexCount; }
+
+    /**
      * @brief Sets point positions from a range of 2D points.
      *
      * @tparam R: Range whose value type satisfies Point2Concept (must provide

--- a/vclib/render/shaders/embedded_vf_programs.config
+++ b/vclib/render/shaders/embedded_vf_programs.config
@@ -165,9 +165,37 @@ PRIMITIVE_LINES
     vclib/shaders/primitives/lines/primitive_lines/vs_primitive_lines.sc
     vclib/shaders/primitives/lines/primitive_lines/fs_primitive_lines.sc
 
-PRIMITIVE_POINTS
-    vclib/shaders/primitives/points/vs_points.sc
-    vclib/shaders/primitives/points/fs_points.sc
+PRIMITIVE_POINTS_PVC_NS_SQ
+    vclib/shaders/primitives/points/vs_points_pvc_ns.sc
+    vclib/shaders/primitives/points/fs_points_ns_sq.sc
+
+PRIMITIVE_POINTS_PVC_NS_CIR
+    vclib/shaders/primitives/points/vs_points_pvc_ns.sc
+    vclib/shaders/primitives/points/fs_points_ns_cir.sc
+
+PRIMITIVE_POINTS_PVC_PVS_SQ
+    vclib/shaders/primitives/points/vs_points_pvc_pvs.sc
+    vclib/shaders/primitives/points/fs_points_pvs_sq.sc
+
+PRIMITIVE_POINTS_PVC_PVS_CIR
+    vclib/shaders/primitives/points/vs_points_pvc_pvs.sc
+    vclib/shaders/primitives/points/fs_points_pvs_cir.sc
+
+PRIMITIVE_POINTS_GC_NS_SQ
+    vclib/shaders/primitives/points/vs_points_gc_ns.sc
+    vclib/shaders/primitives/points/fs_points_ns_sq.sc
+
+PRIMITIVE_POINTS_GC_NS_CIR
+    vclib/shaders/primitives/points/vs_points_gc_ns.sc
+    vclib/shaders/primitives/points/fs_points_ns_cir.sc
+
+PRIMITIVE_POINTS_GC_PVS_SQ
+    vclib/shaders/primitives/points/vs_points_gc_pvs.sc
+    vclib/shaders/primitives/points/fs_points_pvs_sq.sc
+
+PRIMITIVE_POINTS_GC_PVS_CIR
+    vclib/shaders/primitives/points/vs_points_gc_pvs.sc
+    vclib/shaders/primitives/points/fs_points_pvs_cir.sc
 
 SCREENSPACE_BOX
     vclib/shaders/screenspace/overlay/screenspace_box/vs_screenspace_box.sc

--- a/vclib/render/shaders/embedded_vf_programs.config
+++ b/vclib/render/shaders/embedded_vf_programs.config
@@ -165,6 +165,10 @@ PRIMITIVE_LINES
     vclib/shaders/primitives/lines/primitive_lines/vs_primitive_lines.sc
     vclib/shaders/primitives/lines/primitive_lines/fs_primitive_lines.sc
 
+PRIMITIVE_POINTS
+    vclib/shaders/primitives/points/vs_points.sc
+    vclib/shaders/primitives/points/fs_points.sc
+
 SCREENSPACE_BOX
     vclib/shaders/screenspace/overlay/screenspace_box/vs_screenspace_box.sc
     vclib/shaders/screenspace/overlay/screenspace_box/fs_screenspace_box.sc

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/points_instance/vs_points_instance.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/points_instance/vs_points_instance.sc
@@ -33,11 +33,10 @@ void main()
     vec2 quadUv = vec2(idx & 1u, (idx >> 1) & 1u);
     vec4 offset = vec4(
         // {-1, +1} * width * texel
-        (2.0 * quadUv.x - 1.0) * u_pointWidth * u_viewTexel.x, // is divided by 2
-        (2.0 * quadUv.y - 1.0) * u_pointWidth * u_viewTexel.y, // is divided by 2
+        (2.0 * quadUv.x - 1.0) * u_pointWidth * u_viewTexel.x * pos.w, // is divided by 2
+        (2.0 * quadUv.y - 1.0) * u_pointWidth * u_viewTexel.y * pos.w, // is divided by 2
         0, 0);
 
-    pos = pos / pos.w;
     gl_Position = pos + offset;
     v_normal = normalize(mul(u_normalMatrix, a_normal));
 

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/points_instance_id/vs_points_instance_id.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/points_instance_id/vs_points_instance_id.sc
@@ -33,11 +33,10 @@ void main()
     vec2 quadUv = vec2(idx & 1u, (idx >> 1) & 1u);
     vec4 offset = vec4(
         // {-1, +1} * width * texel
-        (2.0 * quadUv.x - 1.0) * u_pointWidth * u_viewTexel.x, // is divided by 2
-        (2.0 * quadUv.y - 1.0) * u_pointWidth * u_viewTexel.y, // is divided by 2
+        (2.0 * quadUv.x - 1.0) * u_pointWidth * u_viewTexel.x * pos.w, // is divided by 2
+        (2.0 * quadUv.y - 1.0) * u_pointWidth * u_viewTexel.y * pos.w, // is divided by 2
         0, 0);
 
-    pos = pos / pos.w;
     gl_Position = pos + offset;
 
     // quad parametrization

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points.sc
@@ -1,0 +1,64 @@
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+$input v_normal, v_texcoord1
+
+#include <vclib/bgfx/shaders_common.sh>
+
+BUFFER_RO(vertexColors, uint, 2); // colors (rgba as float bits)
+
+void main()
+{
+//    // defaul color and light
+//    vec4 light = vec4(1, 1, 1, 1);
+//    vec4 color = uintABGRToVec4Color(floatBitsToUint(u_userPointColorFloat));
+//
+//    // circle mode (if outside of the circle, discard)
+//    bool isCircle = bool(u_pointsMode & posToBitFlag(VCL_MRS_POINTS_CIRCLE));
+//    bool isSphere = bool(u_pointsMode & posToBitFlag(VCL_MRS_POINTS_SPHERE));
+//    if (isCircle || isSphere) {
+//        vec2 uv = v_texcoord1 * 2.0 - vec2(1.0, 1.0);
+//        if (length(uv) > 1.0) {
+//            discard;
+//        }
+//        if (isSphere) {
+//            // sphere mode
+//            v_normal = normalize(vec3(uv.x, uv.y, sqrt(1.0 - dot(uv, uv))));
+//        }
+//    }
+//
+//    if (bool(u_pointsMode & posToBitFlag(VCL_MRS_POINTS_SHADING_VERT))) {
+//        light = computeLight(u_lightDir, u_lightColor, v_normal);
+//    }
+//
+//    if (bool(u_pointsMode & posToBitFlag(VCL_MRS_POINTS_COLOR_VERTEX))) {
+//        uint pointId = uint(gl_PrimitiveID) / 2u;
+//        color = uintABGRToVec4Color(vertexColors[pointId]);
+//    }
+//    else if (bool(u_pointsMode & posToBitFlag(VCL_MRS_POINTS_COLOR_MESH))) {
+//        color = u_meshColor;
+//    }
+//
+//    // NO depth writing (it kills performance)
+//    gl_FragColor = light * color; // + vec4(specular, 0);
+    gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+}

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points.sc
@@ -20,45 +20,28 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-$input v_normal, v_texcoord1
+$input v_normal, v_texcoord1, v_color
 
+#include <vclib/bgfx/drawable/uniforms/directional_light_uniforms.sh>
+#include <vclib/bgfx/primitives/uniforms/points_uniforms.sh>
 #include <vclib/bgfx/shaders_common.sh>
-
-BUFFER_RO(vertexColors, uint, 2); // colors (rgba as float bits)
 
 void main()
 {
-//    // defaul color and light
-//    vec4 light = vec4(1, 1, 1, 1);
-//    vec4 color = uintABGRToVec4Color(floatBitsToUint(u_userPointColorFloat));
-//
-//    // circle mode (if outside of the circle, discard)
-//    bool isCircle = bool(u_pointsMode & posToBitFlag(VCL_MRS_POINTS_CIRCLE));
-//    bool isSphere = bool(u_pointsMode & posToBitFlag(VCL_MRS_POINTS_SPHERE));
-//    if (isCircle || isSphere) {
-//        vec2 uv = v_texcoord1 * 2.0 - vec2(1.0, 1.0);
-//        if (length(uv) > 1.0) {
-//            discard;
-//        }
-//        if (isSphere) {
-//            // sphere mode
-//            v_normal = normalize(vec3(uv.x, uv.y, sqrt(1.0 - dot(uv, uv))));
-//        }
-//    }
-//
-//    if (bool(u_pointsMode & posToBitFlag(VCL_MRS_POINTS_SHADING_VERT))) {
-//        light = computeLight(u_lightDir, u_lightColor, v_normal);
-//    }
-//
-//    if (bool(u_pointsMode & posToBitFlag(VCL_MRS_POINTS_COLOR_VERTEX))) {
-//        uint pointId = uint(gl_PrimitiveID) / 2u;
-//        color = uintABGRToVec4Color(vertexColors[pointId]);
-//    }
-//    else if (bool(u_pointsMode & posToBitFlag(VCL_MRS_POINTS_COLOR_MESH))) {
-//        color = u_meshColor;
-//    }
-//
-//    // NO depth writing (it kills performance)
-//    gl_FragColor = light * color; // + vec4(specular, 0);
-    gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+    vec4 color = v_color;
+
+    if (!useQuadShape()) {
+        // circle mode (if outside of the circle, discard)
+        vec2 uv = v_texcoord1 * 2.0 - vec2(1.0, 1.0);
+        if (length(uv) > 1.0) {
+            discard;
+        }
+    }
+
+    vec4 light = vec4(1.0, 1.0, 1.0, 1.0);
+    if (!useNoneShading()) {
+        light = computeLight(u_lightDir, u_lightColor, v_normal);
+    }
+
+    gl_FragColor = light * color;
 }

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_in.sh
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_in.sh
@@ -30,18 +30,18 @@ void main()
 {
     vec4 color = v_color;
 
-    if (!useQuadShape()) {
-        // circle mode (if outside of the circle, discard)
-        vec2 uv = v_texcoord1 * 2.0 - vec2(1.0, 1.0);
-        if (length(uv) > 1.0) {
-            discard;
-        }
+#if !POINTS_SHAPE_SQUARE
+    // circle mode (if outside of the circle, discard)
+    vec2 uv = v_texcoord1 * 2.0 - vec2(1.0, 1.0);
+    if (length(uv) > 1.0) {
+        discard;
     }
+#endif
 
     vec4 light = vec4(1.0, 1.0, 1.0, 1.0);
-    if (!useNoneShading()) {
-        light = computeLight(u_lightDir, u_lightColor, v_normal);
-    }
+#if !POINTS_SHADING_NONE
+    light = computeLight(u_lightDir, u_lightColor, v_normal);
+#endif
 
     gl_FragColor = light * color;
 }

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_in.sh
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_in.sh
@@ -39,7 +39,7 @@ void main()
 #endif
 
     vec4 light = vec4(1.0, 1.0, 1.0, 1.0);
-#if !POINTS_SHADING_NONE
+#if POINTS_SHADING_PER_VERTEX
     light = computeLight(u_lightDir, u_lightColor, v_normal);
 #endif
 

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_ns_cir.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_ns_cir.sc
@@ -1,0 +1,3 @@
+#define POINTS_SHADING_NONE 1
+#define POINTS_SHAPE_SQUARE 0
+#include "fs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_ns_cir.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_ns_cir.sc
@@ -1,3 +1,28 @@
-#define POINTS_SHADING_NONE 1
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+// no shading, circle shape
+
+#define POINTS_SHADING_PER_VERTEX 0
 #define POINTS_SHAPE_SQUARE 0
+
 #include "fs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_ns_sq.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_ns_sq.sc
@@ -1,0 +1,3 @@
+#define POINTS_SHADING_NONE 1
+#define POINTS_SHAPE_SQUARE 1
+#include "fs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_ns_sq.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_ns_sq.sc
@@ -1,3 +1,28 @@
-#define POINTS_SHADING_NONE 1
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+// no shading, square shape
+
+#define POINTS_SHADING_PER_VERTEX 0
 #define POINTS_SHAPE_SQUARE 1
+
 #include "fs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_pvs_cir.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_pvs_cir.sc
@@ -1,3 +1,28 @@
-#define POINTS_SHADING_NONE 0
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+// per vertex shading, circle shape
+
+#define POINTS_SHADING_PER_VERTEX 1
 #define POINTS_SHAPE_SQUARE 0
+
 #include "fs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_pvs_cir.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_pvs_cir.sc
@@ -1,0 +1,3 @@
+#define POINTS_SHADING_NONE 0
+#define POINTS_SHAPE_SQUARE 0
+#include "fs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_pvs_sq.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_pvs_sq.sc
@@ -1,3 +1,28 @@
-#define POINTS_SHADING_NONE 0
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+// per vertex shading, square shape
+
+#define POINTS_SHADING_PER_VERTEX 1
 #define POINTS_SHAPE_SQUARE 1
+
 #include "fs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_pvs_sq.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/fs_points_pvs_sq.sc
@@ -1,0 +1,3 @@
+#define POINTS_SHADING_NONE 0
+#define POINTS_SHAPE_SQUARE 1
+#include "fs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/varying.def.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/varying.def.sc
@@ -1,5 +1,3 @@
-vec3 a_position  : POSITION;
-vec3 a_normal    : NORMAL;
-
 vec3 v_normal    : NORMAL;
 vec2 v_texcoord1 : TEXCOORD1;
+flat vec4 v_color : COLOR0;

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/varying.def.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/varying.def.sc
@@ -1,0 +1,5 @@
+vec3 a_position  : POSITION;
+vec3 a_normal    : NORMAL;
+
+vec3 v_normal    : NORMAL;
+vec2 v_texcoord1 : TEXCOORD1;

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points.sc
@@ -20,28 +20,64 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-$input a_position, a_normal
-$output v_normal, v_texcoord1
+$output v_normal, v_texcoord1, v_color
 
 #include <vclib/bgfx/shaders_common.sh>
+#include <vclib/bgfx/primitives/uniforms/points_uniforms.sh>
+
+BUFFER_RO(pointsBuffer, vec4, 0); // 3D point positions
+BUFFER_RO(normalsBuffer, vec4, 1); // 3D normals
+BUFFER_RO(pointColors, uint, 2); // colors
 
 void main()
 {
-//    uint idx = uint(gl_VertexID) & 3u; // last 2 bits
-//    // (bit 0 = x axis, bit 1 = y axis)
-//    vec4 pos = mul(u_modelViewProj, vec4(a_position, 1.0));
-//    vec2 quadUv = vec2(idx & 1u, (idx >> 1) & 1u);
-//    vec4 offset = vec4(
-//        // {-1, +1} * width * texel
-//        (2.0 * quadUv.x - 1.0) * u_pointWidth * u_viewTexel.x, // is divided by 2
-//        (2.0 * quadUv.y - 1.0) * u_pointWidth * u_viewTexel.y, // is divided by 2
-//        0, 0);
-//
-//    pos = pos / pos.w;
-//    gl_Position = pos + offset;
-//    v_normal = normalize(mul(u_normalMatrix, a_normal));
-//
-//    // quad parametrization
-//    v_texcoord1 = quadUv;
-    gl_Position = mul(u_modelViewProj, vec4(a_position, 1.0));
+    // Calculate which point and which vertex of the quad we're processing
+    // Each point generates 6 vertices (2 triangles)
+    uint pointIndex = gl_VertexID / 6u;
+    uint localVertex = gl_VertexID % 6u;
+
+    uint idx30 = pointIndex * 3u;
+    uint idx31 = idx30 + 1u;
+    uint idx32 = idx30 + 2u;
+
+    vec3 centerPos = vec3(
+        pointsBuffer[idx30/4u][idx30%4u],
+        pointsBuffer[idx31/4u][idx31%4u],
+        pointsBuffer[idx32/4u][idx32%4u]);
+
+    const vec2 offsets[6] = {
+        vec2(-1.0, -1.0), vec2(-1.0,  1.0), vec2( 1.0, -1.0),
+        vec2( 1.0, -1.0), vec2(-1.0,  1.0), vec2( 1.0,  1.0)
+    };
+
+    vec2 quadUv = offsets[localVertex] * 0.5 + 0.5;
+
+    vec4 pos = mul(u_modelViewProj, vec4(centerPos, 1.0));
+    
+    vec4 offset = vec4(
+        offsets[localVertex].x * u_pointsWidth * u_viewTexel.x,
+        offsets[localVertex].y * u_pointsWidth * u_viewTexel.y,
+        0.0, 0.0);
+
+    pos = pos / pos.w;
+    gl_Position = pos + offset;
+
+    // Normal calculation
+    vec3 normal = vec3(0.0, 0.0, 1.0);
+    if (!useNoneShading()) {
+        normal = vec3(
+            normalsBuffer[idx30/4u][idx30%4u],
+            normalsBuffer[idx31/4u][idx31%4u],
+            normalsBuffer[idx32/4u][idx32%4u]);
+    }
+    v_normal = normalize(mul(u_normalMatrix, normal));
+
+    // Color calculation
+    v_color = u_pointsGeneralColor;
+    if (usePerPointColor()) {
+        v_color = uintABGRToVec4Color(pointColors[pointIndex]);
+    }
+
+    // Pass UV coordinates to fragment shader
+    v_texcoord1 = quadUv;
 }

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points.sc
@@ -55,11 +55,10 @@ void main()
     vec4 pos = mul(u_modelViewProj, vec4(centerPos, 1.0));
     
     vec4 offset = vec4(
-        offsets[localVertex].x * u_pointsWidth * u_viewTexel.x,
-        offsets[localVertex].y * u_pointsWidth * u_viewTexel.y,
+        offsets[localVertex].x * u_pointsWidth * u_viewTexel.x * pos.w,
+        offsets[localVertex].y * u_pointsWidth * u_viewTexel.y * pos.w,
         0.0, 0.0);
 
-    pos = pos / pos.w;
     gl_Position = pos + offset;
 
     // Normal calculation

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points.sc
@@ -63,7 +63,7 @@ void main()
     gl_Position = pos + offset;
 
     // Normal calculation
-    vec3 normal = vec3(0.0, 0.0, 1.0);
+    vec3 normal = vec3(0.0, 0.0, 0.0);
     if (!useNoneShading()) {
         normal = vec3(
             normalsBuffer[idx30/4u][idx30%4u],

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points.sc
@@ -1,0 +1,47 @@
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+$input a_position, a_normal
+$output v_normal, v_texcoord1
+
+#include <vclib/bgfx/shaders_common.sh>
+
+void main()
+{
+//    uint idx = uint(gl_VertexID) & 3u; // last 2 bits
+//    // (bit 0 = x axis, bit 1 = y axis)
+//    vec4 pos = mul(u_modelViewProj, vec4(a_position, 1.0));
+//    vec2 quadUv = vec2(idx & 1u, (idx >> 1) & 1u);
+//    vec4 offset = vec4(
+//        // {-1, +1} * width * texel
+//        (2.0 * quadUv.x - 1.0) * u_pointWidth * u_viewTexel.x, // is divided by 2
+//        (2.0 * quadUv.y - 1.0) * u_pointWidth * u_viewTexel.y, // is divided by 2
+//        0, 0);
+//
+//    pos = pos / pos.w;
+//    gl_Position = pos + offset;
+//    v_normal = normalize(mul(u_normalMatrix, a_normal));
+//
+//    // quad parametrization
+//    v_texcoord1 = quadUv;
+    gl_Position = mul(u_modelViewProj, vec4(a_position, 1.0));
+}

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_gc_ns.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_gc_ns.sc
@@ -1,3 +1,28 @@
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+// general color, none shading
+
 #define POINTS_COLOR_PER_VERTEX 0
-#define POINTS_SHADING_NONE 1
+#define POINTS_SHADING_PER_VERTEX 0
+
 #include "vs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_gc_ns.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_gc_ns.sc
@@ -1,0 +1,3 @@
+#define POINTS_COLOR_PER_VERTEX 0
+#define POINTS_SHADING_NONE 1
+#include "vs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_gc_pvs.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_gc_pvs.sc
@@ -1,3 +1,28 @@
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+// general color, per vertex shading
+
 #define POINTS_COLOR_PER_VERTEX 0
-#define POINTS_SHADING_NONE 0
+#define POINTS_SHADING_PER_VERTEX 1
+
 #include "vs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_gc_pvs.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_gc_pvs.sc
@@ -1,0 +1,3 @@
+#define POINTS_COLOR_PER_VERTEX 0
+#define POINTS_SHADING_NONE 0
+#include "vs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_in.sh
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_in.sh
@@ -71,15 +71,16 @@ void main()
     gl_Position = pos + offset;
 
     // Normal calculation
-    vec3 normal = vec3(0.0, 0.0, 0.0);
 #if POINTS_SHADING_PER_VERTEX
     // Same vec4 unrolling logic as point positions
-    normal = vec3(
+    v_normal = vec3(
         normalsBuffer[idx30/4u][idx30%4u],
         normalsBuffer[idx31/4u][idx31%4u],
         normalsBuffer[idx32/4u][idx32%4u]);
+    v_normal = normalize(mul(u_normalMatrix, v_normal));
+#else
+    v_normal = vec3(0.0, 0.0, 1.0);
 #endif
-    v_normal = normalize(mul(u_normalMatrix, normal));
 
     // Color calculation
 #if POINTS_COLOR_PER_VERTEX

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_in.sh
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_in.sh
@@ -27,7 +27,7 @@ $output v_normal, v_texcoord1, v_color
 
 BUFFER_RO(pointsBuffer, vec4, 0); // 3D point positions
 
-#if !POINTS_SHADING_NONE
+#if POINTS_SHADING_PER_VERTEX
 BUFFER_RO(normalsBuffer, vec4, 1); // 3D normals
 #endif
 
@@ -69,7 +69,7 @@ void main()
 
     // Normal calculation
     vec3 normal = vec3(0.0, 0.0, 0.0);
-#if !POINTS_SHADING_NONE
+#if POINTS_SHADING_PER_VERTEX
     normal = vec3(
         normalsBuffer[idx30/4u][idx30%4u],
         normalsBuffer[idx31/4u][idx31%4u],

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_in.sh
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_in.sh
@@ -26,8 +26,14 @@ $output v_normal, v_texcoord1, v_color
 #include <vclib/bgfx/primitives/uniforms/points_uniforms.sh>
 
 BUFFER_RO(pointsBuffer, vec4, 0); // 3D point positions
+
+#if !POINTS_SHADING_NONE
 BUFFER_RO(normalsBuffer, vec4, 1); // 3D normals
+#endif
+
+#if POINTS_COLOR_PER_VERTEX
 BUFFER_RO(pointColors, uint, 2); // colors
+#endif
 
 void main()
 {
@@ -63,19 +69,20 @@ void main()
 
     // Normal calculation
     vec3 normal = vec3(0.0, 0.0, 0.0);
-    if (!useNoneShading()) {
-        normal = vec3(
-            normalsBuffer[idx30/4u][idx30%4u],
-            normalsBuffer[idx31/4u][idx31%4u],
-            normalsBuffer[idx32/4u][idx32%4u]);
-    }
+#if !POINTS_SHADING_NONE
+    normal = vec3(
+        normalsBuffer[idx30/4u][idx30%4u],
+        normalsBuffer[idx31/4u][idx31%4u],
+        normalsBuffer[idx32/4u][idx32%4u]);
+#endif
     v_normal = normalize(mul(u_normalMatrix, normal));
 
     // Color calculation
+#if POINTS_COLOR_PER_VERTEX
+    v_color = uintABGRToVec4Color(pointColors[pointIndex]);
+#else
     v_color = u_pointsGeneralColor;
-    if (usePerPointColor()) {
-        v_color = uintABGRToVec4Color(pointColors[pointIndex]);
-    }
+#endif
 
     // Pass UV coordinates to fragment shader
     v_texcoord1 = quadUv;

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_in.sh
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_in.sh
@@ -46,6 +46,9 @@ void main()
     uint idx31 = idx30 + 1u;
     uint idx32 = idx30 + 2u;
 
+    // Unroll a continuous stream of floats from a vec4 compute buffer.
+    // Each point's position takes 3 floats, but the SSBO is accessed as vec4 elements.
+    // idx/4u computes the vec4 index, and idx%4u selects the correct scalar component.
     vec3 centerPos = vec3(
         pointsBuffer[idx30/4u][idx30%4u],
         pointsBuffer[idx31/4u][idx31%4u],
@@ -70,6 +73,7 @@ void main()
     // Normal calculation
     vec3 normal = vec3(0.0, 0.0, 0.0);
 #if POINTS_SHADING_PER_VERTEX
+    // Same vec4 unrolling logic as point positions
     normal = vec3(
         normalsBuffer[idx30/4u][idx30%4u],
         normalsBuffer[idx31/4u][idx31%4u],

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_pvc_ns.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_pvc_ns.sc
@@ -1,0 +1,3 @@
+#define POINTS_COLOR_PER_VERTEX 1
+#define POINTS_SHADING_NONE 1
+#include "vs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_pvc_ns.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_pvc_ns.sc
@@ -1,3 +1,28 @@
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+// per vertex color, none shading
+
 #define POINTS_COLOR_PER_VERTEX 1
-#define POINTS_SHADING_NONE 1
+#define POINTS_SHADING_PER_VERTEX 0
+
 #include "vs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_pvc_pvs.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_pvc_pvs.sc
@@ -1,0 +1,3 @@
+#define POINTS_COLOR_PER_VERTEX 1
+#define POINTS_SHADING_NONE 0
+#include "vs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_pvc_pvs.sc
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_pvc_pvs.sc
@@ -1,3 +1,28 @@
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+// per vertex color, per vertex shading
+
 #define POINTS_COLOR_PER_VERTEX 1
-#define POINTS_SHADING_NONE 0
+#define POINTS_SHADING_PER_VERTEX 1
+
 #include "vs_points_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/primitives/uniforms/points_uniforms.sh
+++ b/vclib/render/shaders/vclib/bgfx/primitives/uniforms/points_uniforms.sh
@@ -27,20 +27,7 @@
 
 uniform vec4 u_pointsSettings;
 
-#define u_pointsSettingPack floatBitsToUint(u_pointsSettings.x)
-#define u_pointsWidth u_pointsSettings.y
-#define u_pointsGeneralColor uintABGRToVec4Color(floatBitsToUint(u_pointsSettings.z))
-
-uint usePerPointColor() {
-    return uint(u_pointsSettingPack & posToBitFlag(0u));
-}
-
-uint useNoneShading() {
-    return uint(u_pointsSettingPack & posToBitFlag(1u));
-}
-
-uint useQuadShape() {
-    return uint(u_pointsSettingPack & posToBitFlag(2u));
-}
+#define u_pointsWidth u_pointsSettings.x
+#define u_pointsGeneralColor uintABGRToVec4Color(floatBitsToUint(u_pointsSettings.y))
 
 #endif // VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_SH

--- a/vclib/render/shaders/vclib/bgfx/primitives/uniforms/points_uniforms.sh
+++ b/vclib/render/shaders/vclib/bgfx/primitives/uniforms/points_uniforms.sh
@@ -23,19 +23,24 @@
 #ifndef VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_SH
 #define VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_SH
 
+#include <vclib/shaders_common.sh>
+
 uniform vec4 u_pointsSettings;
 
-#define u_pointsColorToUse floatBitsToUint(u_pointsSettings.x)
-#define u_pointsShadeMode floatBitsToUint(u_pointsSettings.y)
-#define u_pointsWidth u_pointsSettings.z
-#define u_pointsGeneralColor uintABGRToVec4Color(floatBitsToUint(u_pointsSettings.w))
+#define u_pointsSettingPack uintBitsToFloat(u_pointsSettings.x)
+#define u_pointsWidth u_pointsSettings.y
+#define u_pointsGeneralColor uintABGRToVec4Color(floatBitsToUint(u_pointsSettings.z))
 
 bool usePerPointColor() {
-    return u_pointsColorToUse == 0u;
+    return bool(u_pointsSettingPack & posToBitFlag(0u));
+}
+
+bool useNoneShading() {
+    return bool(u_pointsSettingPack & posToBitFlag(1u));
 }
 
 bool useQuadShape() {
-    return u_pointsShadeMode == 0u;
+    return bool(u_pointsSettingPack & posToBitFlag(2u));
 }
 
 #endif // VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_SH

--- a/vclib/render/shaders/vclib/bgfx/primitives/uniforms/points_uniforms.sh
+++ b/vclib/render/shaders/vclib/bgfx/primitives/uniforms/points_uniforms.sh
@@ -23,11 +23,11 @@
 #ifndef VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_SH
 #define VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_SH
 
-#include <vclib/shaders_common.sh>
+#include <vclib/bgfx/shaders_common.sh>
 
 uniform vec4 u_pointsSettings;
 
-#define u_pointsSettingPack uintBitsToFloat(u_pointsSettings.x)
+#define u_pointsSettingPack floatBitsToUint(u_pointsSettings.x)
 #define u_pointsWidth u_pointsSettings.y
 #define u_pointsGeneralColor uintABGRToVec4Color(floatBitsToUint(u_pointsSettings.z))
 

--- a/vclib/render/shaders/vclib/bgfx/primitives/uniforms/points_uniforms.sh
+++ b/vclib/render/shaders/vclib/bgfx/primitives/uniforms/points_uniforms.sh
@@ -1,0 +1,41 @@
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+#ifndef VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_SH
+#define VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_SH
+
+uniform vec4 u_pointsSettings;
+
+#define u_pointsColorToUse floatBitsToUint(u_pointsSettings.x)
+#define u_pointsShadeMode floatBitsToUint(u_pointsSettings.y)
+#define u_pointsWidth u_pointsSettings.z
+#define u_pointsGeneralColor uintABGRToVec4Color(floatBitsToUint(u_pointsSettings.w))
+
+bool usePerPointColor() {
+    return u_pointsColorToUse == 0u;
+}
+
+bool useQuadShape() {
+    return u_pointsShadeMode == 0u;
+}
+
+#endif // VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_SH

--- a/vclib/render/shaders/vclib/bgfx/primitives/uniforms/points_uniforms.sh
+++ b/vclib/render/shaders/vclib/bgfx/primitives/uniforms/points_uniforms.sh
@@ -31,16 +31,16 @@ uniform vec4 u_pointsSettings;
 #define u_pointsWidth u_pointsSettings.y
 #define u_pointsGeneralColor uintABGRToVec4Color(floatBitsToUint(u_pointsSettings.z))
 
-bool usePerPointColor() {
-    return bool(u_pointsSettingPack & posToBitFlag(0u));
+uint usePerPointColor() {
+    return uint(u_pointsSettingPack & posToBitFlag(0u));
 }
 
-bool useNoneShading() {
-    return bool(u_pointsSettingPack & posToBitFlag(1u));
+uint useNoneShading() {
+    return uint(u_pointsSettingPack & posToBitFlag(1u));
 }
 
-bool useQuadShape() {
-    return bool(u_pointsSettingPack & posToBitFlag(2u));
+uint useQuadShape() {
+    return uint(u_pointsSettingPack & posToBitFlag(2u));
 }
 
 #endif // VCL_BGFX_PRIMITIVES_UNIFORMS_POINTS_UNIFORMS_SH

--- a/vclib/render/src/vclib/bgfx/primitives/points.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/points.cpp
@@ -27,6 +27,21 @@
 
 namespace vcl {
 
+/**
+ * @brief Constructs a point set by referencing existing VertexBuffers.
+ *
+ * @param[in] vertexCount: Number of points (length of verts).
+ * @param[in] verts: VertexBuffer containing point positions.
+ * Expected layout: an array of `float` with 3 components per point (x, y,
+ * z), stored as consecutive floats: [x0, y0, z0, x1, y1, z1, ..., xn-1,
+ * yn-1, zn-1]. The buffer must be created for compute access and must
+ * remain valid for the lifetime of this object.
+ * @param[in] vertColors: Optional VertexBuffer containing per-point colors.
+ * Expected layout: an array of `uint` with 4 channels per color in ABGR
+ * order (A, B, G, R packed as a single 32-bit integer). The buffer must be
+ * created for compute access and must remain valid for the lifetime of
+ * this object.
+ */
 Points::Points(
     const uint          vertexCount,
     const VertexBuffer& verts,
@@ -38,17 +53,60 @@ Points::Points(
     }
 }
 
+/**
+ * @brief Sets point positions by referencing an existing VertexBuffer.
+ *
+ * @param[in] vertexCount: Number of points (length of verts).
+ * @param[in] verts: VertexBuffer containing point positions.
+ * Expected layout: an array of `float` with 3 components per point (x, y,
+ * z), stored as consecutive floats: [x0, y0, z0, x1, y1, z1, ..., xn-1,
+ * yn-1, zn-1]. The buffer must be created for compute access and must
+ * remain valid for the lifetime of this object.
+ */
 void Points::setVertices(const uint vertexCount, const VertexBuffer& verts)
 {
     mVertexCount = vertexCount;
     mVertexPositions.setReferenced(&verts);
 }
 
+/**
+ * @brief Sets per-point normals by referencing an existing VertexBuffer.
+ *
+ * @param[in] vertNormals: VertexBuffer containing per-point normals.
+ * Expected layout: an array of `float` with 3 components per normal (x, y,
+ * z), stored as consecutive floats: [nx0, ny0, nz0, nx1, ny1, nz1, ...,
+ * nxn-1, nyn-1, nzn-1]. The buffer must be created for compute access and
+ * must remain valid for the lifetime of this object.
+ */
+void Points::setVertexNormals(const VertexBuffer& vertNormals)
+{
+    mVertexNormals.setReferenced(&vertNormals);
+}
+
+/**
+ * @brief Sets per-point colors by referencing an existing VertexBuffer.
+ *
+ * @param[in] vertColors: VertexBuffer containing per-point colors.
+ * Expected layout: an array of `uint` with 4 channels per color in
+ * ABGR order (A, B, G, R packed as a single 32-bit integer). The buffer
+ * must be created for compute access and must remain valid for the
+ * lifetime of this object.
+ */
 void Points::setVertexColors(const VertexBuffer& vertColors)
 {
     mVertexColors.setReferenced(&vertColors);
 }
 
+/**
+ * @brief Draws the point sprites in world space on the specified view.
+ *
+ * Renders all 3D points as screen-space splats using programmable vertex
+ * pulling. Points are positioned through the standard camera projection,
+ * and each point is expanded into a quad procedurally depending on the
+ * configured Shape setting.
+ *
+ * @param[in] viewId: The bgfx view ID to submit the rendering commands to.
+ */
 void Points::draw(bgfx::ViewId viewId) const
 {
     // Skip rendering if there are no vertices or the position buffer is invalid
@@ -70,9 +128,12 @@ void Points::draw(bgfx::ViewId viewId) const
     mVertexPositions.get().bindCompute(
         POINTS_POSITIONS_STAGE, bgfx::Access::Read);
 
+    if (mVertexNormals.isValid()) {
+        mVertexNormals.get().bindCompute(
+            POINTS_NORMALS_STAGE, bgfx::Access::Read);
+    }
+
     if (mVertexColors.isValid()) {
-        // TODO: bind the per-vertex color buffer as a compute buffer at the
-        // colors stage so the shader can read it.
         mVertexColors.get().bindCompute(
             POINTS_COLORS_STAGE, bgfx::Access::Read);
     }

--- a/vclib/render/src/vclib/bgfx/primitives/points.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/points.cpp
@@ -25,6 +25,8 @@
 #include <vclib/bgfx/context.h>
 #include <vclib/bgfx/primitives/uniforms/points_uniforms.h>
 
+#include <stdexcept>
+
 namespace vcl {
 
 /**
@@ -114,6 +116,8 @@ void Points::draw(bgfx::ViewId viewId) const
         return;
     }
 
+    validityCheck();
+
     Context& ctx = Context::instance();
     ProgramManager& pm = ctx.programManager();
 
@@ -153,6 +157,24 @@ void Points::draw(bgfx::ViewId viewId) const
 
     auto program = pm.getProgram<VertFragProgram::PRIMITIVE_POINTS>();
     bgfx::submit(viewId, program);
+}
+
+void Points::validityCheck() const
+{
+    if (mColorToUse == ColorSetting::PER_VERTEX) {
+        if (!mVertexColors.isValid()) {
+            throw std::runtime_error(
+                "Points: PER_VERTEX color setting requires a "
+                "valid vertex color buffer.");
+        }
+    }
+    if (mShading == Shading::PER_VERTEX) {
+        if (!mVertexNormals.isValid()) {
+            throw std::runtime_error(
+                "Points: PER_VERTEX shading setting requires a "
+                "valid vertex normal buffer.");
+        }
+    }
 }
 
 } // namespace vcl

--- a/vclib/render/src/vclib/bgfx/primitives/points.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/points.cpp
@@ -103,7 +103,7 @@ void Points::setVertexColors(const VertexBuffer& vertColors)
 }
 
 /**
- * @brief Draws the point sprites in world space on the specified view.
+ * @brief Draws the point splats in world space on the specified view.
  *
  * Renders all 3D points as screen-space splats using programmable vertex
  * pulling. Points are positioned through the standard camera projection,

--- a/vclib/render/src/vclib/bgfx/primitives/points.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/points.cpp
@@ -83,6 +83,7 @@ void Points::setVertices(const uint vertexCount, const VertexBuffer& verts)
 void Points::setVertexNormals(const VertexBuffer& vertNormals)
 {
     mVertexNormals.setReferenced(&vertNormals);
+    mIsValidityCheckNeeded = true;
 }
 
 /**
@@ -97,6 +98,7 @@ void Points::setVertexNormals(const VertexBuffer& vertNormals)
 void Points::setVertexColors(const VertexBuffer& vertColors)
 {
     mVertexColors.setReferenced(&vertColors);
+    mIsValidityCheckNeeded = true;
 }
 
 /**
@@ -161,6 +163,10 @@ void Points::draw(bgfx::ViewId viewId) const
 
 void Points::validityCheck() const
 {
+    if (!mIsValidityCheckNeeded) {
+        return;
+    }
+
     if (mColorToUse == ColorSetting::PER_VERTEX) {
         if (!mVertexColors.isValid()) {
             throw std::runtime_error(
@@ -175,6 +181,8 @@ void Points::validityCheck() const
                 "valid vertex normal buffer.");
         }
     }
+
+    mIsValidityCheckNeeded = false;
 }
 
 } // namespace vcl

--- a/vclib/render/src/vclib/bgfx/primitives/points.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/points.cpp
@@ -121,7 +121,7 @@ void Points::draw(bgfx::ViewId viewId) const
     PointsUniforms::setColorSetting(static_cast<uint>(mColorToUse));
     PointsUniforms::setShading(static_cast<uint>(mShading));
     PointsUniforms::setShape(static_cast<uint>(mShape));
-    PointsUniforms::setSize(mSize);
+    PointsUniforms::setWidth(mWidth);
     PointsUniforms::setGeneralColor(mGeneralColor);
 
     // Bind the position buffer as a compute buffer (SSBO) for vertex shader

--- a/vclib/render/src/vclib/bgfx/primitives/points.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/points.cpp
@@ -155,6 +155,13 @@ void Points::draw(bgfx::ViewId viewId) const
     bgfx::submit(viewId, mProgram);
 }
 
+/**
+ * @brief Checks if the shader program needs to be updated and updates it.
+ *
+ * Validates that required buffers (normals, colors) are available based on
+ * the current shading and color settings, throwing an exception if invalid.
+ * Then it selects the appropriate shader program.
+ */
 void Points::checkAndUpdateProgram() const
 {
     if (!mIsUpdateProgramNeeded) {
@@ -180,6 +187,11 @@ void Points::checkAndUpdateProgram() const
     mIsUpdateProgramNeeded = false;
 }
 
+/**
+ * @brief Selects the correct bgfx shader program based on current settings.
+ *
+ * @return The appropriate bgfx::ProgramHandle for the current configuration.
+ */
 bgfx::ProgramHandle Points::pointsProgramSelector() const
 {
     using enum VertFragProgram;
@@ -187,6 +199,10 @@ bgfx::ProgramHandle Points::pointsProgramSelector() const
     Context& ctx = Context::instance();
     ProgramManager& pm = ctx.programManager();
 
+    // Select the program from 8 possible permutations based on:
+    // 1. Color: Per-Vertex Color (PVC) vs General Color (GC)
+    // 2. Shading: Per-Vertex Shading (PVS) vs No Shading (NS)
+    // 3. Shape: Square (SQ) vs Circle (CIR)
     if (mColorToUse == ColorSetting::PER_VERTEX) {
         if (mShading == Shading::NONE) {
             if (mShape == Shape::SQUARE) {

--- a/vclib/render/src/vclib/bgfx/primitives/points.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/points.cpp
@@ -139,17 +139,8 @@ void Points::draw(bgfx::ViewId viewId) const
             POINTS_COLORS_STAGE, bgfx::Access::Read);
     }
 
-    // Each point is expanded into one quad (6 vertices / 2 triangles).
-    // TODO: verify this triangle count matches the intended shader behavior;
-    // adjust if a single-vertex point sprite (e.g., GL_POINTS) is preferred.
     bgfx::setVertexCount(mVertexCount * 6);
 
-    // TODO: configure appropriate rasterization state for world-space points.
-    // Suggested settings (adjust according to the final shader design):
-    //   - Enable depth testing with BGFX_STATE_DEPTH_TEST_LESS so closer points
-    //     occlude farther ones correctly.
-    //   - Write RGB and alpha channels.
-    //   - Optionally enable MSAA-compatible blending: BGFX_STATE_BLEND_ALPHA.
     bgfx::setState(0 |
                    BGFX_STATE_WRITE_RGB        |
                    BGFX_STATE_WRITE_A          |
@@ -159,13 +150,8 @@ void Points::draw(bgfx::ViewId viewId) const
     // Bind the updated uniforms to the shader stage.
     PointsUniforms::bind();
 
-    // TODO: select and submit with the appropriate world-space points program.
-    // Replace the placeholder below with the real program, e.g.:
-    //   bgfx::submit(viewId, pm.getProgram<VertFragProgram::POINTS>());
-    //bgfx::submit(viewId, nullptr);
-
-    // TODO: unbind compute buffers after draw (if not handled automatically
-    // by setComputeTexture or the framework).
+    auto program = pm.getProgram<VertFragProgram::PRIMITIVE_POINTS>();
+    bgfx::submit(viewId, program);
 }
 
 } // namespace vcl

--- a/vclib/render/src/vclib/bgfx/primitives/points.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/points.cpp
@@ -119,6 +119,7 @@ void Points::draw(bgfx::ViewId viewId) const
 
     // Upload rendering settings to the shader via uniform.
     PointsUniforms::setColorSetting(static_cast<uint>(mColorToUse));
+    PointsUniforms::setShading(static_cast<uint>(mShading));
     PointsUniforms::setShape(static_cast<uint>(mShape));
     PointsUniforms::setSize(mSize);
     PointsUniforms::setGeneralColor(mGeneralColor);

--- a/vclib/render/src/vclib/bgfx/primitives/points.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/points.cpp
@@ -144,6 +144,7 @@ void Points::draw(bgfx::ViewId viewId) const
     bgfx::setState(0 |
                    BGFX_STATE_WRITE_RGB        |
                    BGFX_STATE_WRITE_A          |
+                   BGFX_STATE_WRITE_Z          |
                    BGFX_STATE_DEPTH_TEST_LESS  |
                    BGFX_STATE_BLEND_ALPHA);
 

--- a/vclib/render/src/vclib/bgfx/primitives/points.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/points.cpp
@@ -69,6 +69,7 @@ void Points::setVertices(const uint vertexCount, const VertexBuffer& verts)
 {
     mVertexCount = vertexCount;
     mVertexPositions.setReferenced(&verts);
+    mIsUpdateProgramNeeded = true;
 }
 
 /**
@@ -83,7 +84,7 @@ void Points::setVertices(const uint vertexCount, const VertexBuffer& verts)
 void Points::setVertexNormals(const VertexBuffer& vertNormals)
 {
     mVertexNormals.setReferenced(&vertNormals);
-    mIsValidityCheckNeeded = true;
+    mIsUpdateProgramNeeded = true;
 }
 
 /**
@@ -98,7 +99,7 @@ void Points::setVertexNormals(const VertexBuffer& vertNormals)
 void Points::setVertexColors(const VertexBuffer& vertColors)
 {
     mVertexColors.setReferenced(&vertColors);
-    mIsValidityCheckNeeded = true;
+    mIsUpdateProgramNeeded = true;
 }
 
 /**
@@ -118,10 +119,7 @@ void Points::draw(bgfx::ViewId viewId) const
         return;
     }
 
-    validityCheck();
-
-    Context& ctx = Context::instance();
-    ProgramManager& pm = ctx.programManager();
+    checkAndUpdateProgram();
 
     // Upload rendering settings to the shader via uniform.
     PointsUniforms::setWidth(mWidth);
@@ -154,13 +152,12 @@ void Points::draw(bgfx::ViewId viewId) const
     // Bind the updated uniforms to the shader stage.
     PointsUniforms::bind();
 
-    auto program = pointsProgramSelector();
-    bgfx::submit(viewId, program);
+    bgfx::submit(viewId, mProgram);
 }
 
-void Points::validityCheck() const
+void Points::checkAndUpdateProgram() const
 {
-    if (!mIsValidityCheckNeeded) {
+    if (!mIsUpdateProgramNeeded) {
         return;
     }
 
@@ -179,7 +176,8 @@ void Points::validityCheck() const
         }
     }
 
-    mIsValidityCheckNeeded = false;
+    mProgram = pointsProgramSelector();
+    mIsUpdateProgramNeeded = false;
 }
 
 bgfx::ProgramHandle Points::pointsProgramSelector() const

--- a/vclib/render/src/vclib/bgfx/primitives/points.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/points.cpp
@@ -124,9 +124,6 @@ void Points::draw(bgfx::ViewId viewId) const
     ProgramManager& pm = ctx.programManager();
 
     // Upload rendering settings to the shader via uniform.
-    PointsUniforms::setColorSetting(static_cast<uint>(mColorToUse));
-    PointsUniforms::setShading(static_cast<uint>(mShading));
-    PointsUniforms::setShape(static_cast<uint>(mShape));
     PointsUniforms::setWidth(mWidth);
     PointsUniforms::setGeneralColor(mGeneralColor);
 
@@ -157,7 +154,7 @@ void Points::draw(bgfx::ViewId viewId) const
     // Bind the updated uniforms to the shader stage.
     PointsUniforms::bind();
 
-    auto program = pm.getProgram<VertFragProgram::PRIMITIVE_POINTS>();
+    auto program = pointsProgramSelector();
     bgfx::submit(viewId, program);
 }
 
@@ -183,6 +180,44 @@ void Points::validityCheck() const
     }
 
     mIsValidityCheckNeeded = false;
+}
+
+bgfx::ProgramHandle Points::pointsProgramSelector() const
+{
+    using enum VertFragProgram;
+
+    Context& ctx = Context::instance();
+    ProgramManager& pm = ctx.programManager();
+
+    if (mColorToUse == ColorSetting::PER_VERTEX) {
+        if (mShading == Shading::NONE) {
+            if (mShape == Shape::SQUARE) {
+                return pm.getProgram<PRIMITIVE_POINTS_PVC_NS_SQ>();
+            } else {
+                return pm.getProgram<PRIMITIVE_POINTS_PVC_NS_CIR>();
+            }
+        } else {
+            if (mShape == Shape::SQUARE) {
+                return pm.getProgram<PRIMITIVE_POINTS_PVC_PVS_SQ>();
+            } else {
+                return pm.getProgram<PRIMITIVE_POINTS_PVC_PVS_CIR>();
+            }
+        }
+    } else {
+        if (mShading == Shading::NONE) {
+            if (mShape == Shape::SQUARE) {
+                return pm.getProgram<PRIMITIVE_POINTS_GC_NS_SQ>();
+            } else {
+                return pm.getProgram<PRIMITIVE_POINTS_GC_NS_CIR>();
+            }
+        } else {
+            if (mShape == Shape::SQUARE) {
+                return pm.getProgram<PRIMITIVE_POINTS_GC_PVS_SQ>();
+            } else {
+                return pm.getProgram<PRIMITIVE_POINTS_GC_PVS_CIR>();
+            }
+        }
+    }
 }
 
 } // namespace vcl

--- a/vclib/render/src/vclib/bgfx/primitives/points.cpp
+++ b/vclib/render/src/vclib/bgfx/primitives/points.cpp
@@ -1,0 +1,109 @@
+/*****************************************************************************
+ * VCLib                                                                     *
+ * Visual Computing Library                                                  *
+ *                                                                           *
+ * Copyright(C) 2021-2026                                                    *
+ * Visual Computing Lab                                                      *
+ * ISTI - Italian National Research Council                                  *
+ *                                                                           *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This program is free software; you can redistribute it and/or modify      *
+ * it under the terms of the Mozilla Public License Version 2.0 as published *
+ * by the Mozilla Foundation; either version 2 of the License, or            *
+ * (at your option) any later version.                                       *
+ *                                                                           *
+ * This program is distributed in the hope that it will be useful,           *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
+ * Mozilla Public License Version 2.0                                        *
+ * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
+ ****************************************************************************/
+
+#include <vclib/bgfx/primitives/points.h>
+
+#include <vclib/bgfx/context.h>
+#include <vclib/bgfx/primitives/uniforms/points_uniforms.h>
+
+namespace vcl {
+
+Points::Points(
+    const uint          vertexCount,
+    const VertexBuffer& verts,
+    const VertexBuffer& vertColors)
+{
+    setVertices(vertexCount, verts);
+    if (vertColors.isValid()) {
+        setVertexColors(vertColors);
+    }
+}
+
+void Points::setVertices(const uint vertexCount, const VertexBuffer& verts)
+{
+    mVertexCount = vertexCount;
+    mVertexPositions.setReferenced(&verts);
+}
+
+void Points::setVertexColors(const VertexBuffer& vertColors)
+{
+    mVertexColors.setReferenced(&vertColors);
+}
+
+void Points::draw(bgfx::ViewId viewId) const
+{
+    // Skip rendering if there are no vertices or the position buffer is invalid
+    if (mVertexCount == 0 || !mVertexPositions.isValid()) {
+        return;
+    }
+
+    Context& ctx = Context::instance();
+    ProgramManager& pm = ctx.programManager();
+
+    // Upload rendering settings to the shader via uniform.
+    PointsUniforms::setColorSetting(static_cast<uint>(mColorToUse));
+    PointsUniforms::setShape(static_cast<uint>(mShape));
+    PointsUniforms::setSize(mSize);
+    PointsUniforms::setGeneralColor(mGeneralColor);
+
+    // Bind the position buffer as a compute buffer (SSBO) for vertex shader
+    // access. The point positions are read by the vertex pulling mechanism.
+    mVertexPositions.get().bindCompute(
+        POINTS_POSITIONS_STAGE, bgfx::Access::Read);
+
+    if (mVertexColors.isValid()) {
+        // TODO: bind the per-vertex color buffer as a compute buffer at the
+        // colors stage so the shader can read it.
+        mVertexColors.get().bindCompute(
+            POINTS_COLORS_STAGE, bgfx::Access::Read);
+    }
+
+    // Each point is expanded into one quad (6 vertices / 2 triangles).
+    // TODO: verify this triangle count matches the intended shader behavior;
+    // adjust if a single-vertex point sprite (e.g., GL_POINTS) is preferred.
+    bgfx::setVertexCount(mVertexCount * 6);
+
+    // TODO: configure appropriate rasterization state for world-space points.
+    // Suggested settings (adjust according to the final shader design):
+    //   - Enable depth testing with BGFX_STATE_DEPTH_TEST_LESS so closer points
+    //     occlude farther ones correctly.
+    //   - Write RGB and alpha channels.
+    //   - Optionally enable MSAA-compatible blending: BGFX_STATE_BLEND_ALPHA.
+    bgfx::setState(0 |
+                   BGFX_STATE_WRITE_RGB        |
+                   BGFX_STATE_WRITE_A          |
+                   BGFX_STATE_DEPTH_TEST_LESS  |
+                   BGFX_STATE_BLEND_ALPHA);
+
+    // Bind the updated uniforms to the shader stage.
+    PointsUniforms::bind();
+
+    // TODO: select and submit with the appropriate world-space points program.
+    // Replace the placeholder below with the real program, e.g.:
+    //   bgfx::submit(viewId, pm.getProgram<VertFragProgram::POINTS>());
+    //bgfx::submit(viewId, nullptr);
+
+    // TODO: unbind compute buffers after draw (if not handled automatically
+    // by setComputeTexture or the framework).
+}
+
+} // namespace vcl


### PR DESCRIPTION
## Overview
This PR introduces the `Points` primitive and the `DrawablePoints` class to the `vclib` rendering module. These additions enable efficient, highly customizable point rendering using `bgfx`. Alongside the core rendering capabilities, a new interactive Qt-based example (`09-drawable-points`) is provided to demonstrate the features.

## Key Changes & Features

### Core Rendering (`vclib::Points` & `vclib::DrawablePoints`)
- **Configurable Shapes**: Support for rendering points as either Squares or Circles.
- **Color Modes**: Support for both Global Color and Per-Vertex Color.
- **Shading Modes**: Added "No Shading" and "Per-Vertex Shading" modes (shading requires vertex normals).
- **Robust State Validation**: Implemented an automated program update and validity checking mechanism. It dynamically updates the shader program and ensures the required vertex buffers (normals, colors) are present for the currently selected rendering state, avoiding runtime crashes.
- **Uniforms & Shaders**: Introduced `PointsUniforms` to manage point widths, shapes, and other properties. Added dedicated, modular `bgfx` shaders (`fs_points_*`, `vs_points_*`) for different rendering configurations.
- **Depth Testing**: Fixed depth testing behavior for primitive points.

### Examples
- **`09-drawable-points`**: A new interactive Qt example that demonstrates the capabilities of `DrawablePoints`.
  - Loads a 3D model (a bunny mesh) and extracts its vertices to render as a point cloud.
  - Includes a UI control panel to toggle between Square and Circle shapes, adjust point width, and switch between shading modes in real-time.
  - Implements random color assignment to showcase per-vertex colors.

## Related Work & Refactoring
- Optimized validation checks to occur only when relevant settings or buffers are modified using dirty flags.
- Split and modularized point shaders for easier maintenance and compilation.
- Updated `embedded_vf_programs.config` to package the new shaders.
