### PR TITLE
Refactor mesh surface shaders and render buffers

### DIFF
--- a/vclib/render/include/vclib/bgfx/drawable/mesh/mesh_render_buffers.h
+++ b/vclib/render/include/vclib/bgfx/drawable/mesh/mesh_render_buffers.h
@@ -68,7 +68,7 @@ class MeshRenderBuffers : public MeshRenderData<MeshRenderBuffers<Mesh>>
 
     IndexBuffer mTriangleIndexBuffer;
     IndexBuffer mTriangleNormalBuffer;
-    IndexBuffer mTriangleColorBuffer;
+    VertexBuffer mTriangleColorBuffer;
 
     Lines mEdgeLines;
 
@@ -234,7 +234,7 @@ public:
 
         mTriangleNormalBuffer.bind(VCL_MRB_PRIMITIVE_NORMAL_BUFFER);
 
-        mTriangleColorBuffer.bind(VCL_MRB_PRIMITIVE_COLOR_BUFFER);
+        mTriangleColorBuffer.bindCompute(VCL_MRB_PRIMITIVE_COLOR_BUFFER);
     }
 
     void drawEdgeLines(uint viewId) const { mEdgeLines.draw(viewId); }
@@ -525,7 +525,14 @@ private:
 
         Base::fillTriangleColors(mesh, buffer, Color::Format::ABGR);
 
-        mTriangleColorBuffer.create(buffer, nt, releaseFn);
+        mTriangleColorBuffer.create(
+            buffer,
+            nt,
+            bgfx::Attrib::Color0,
+            4,
+            PrimitiveType::UCHAR,
+            true,
+            releaseFn);
     }
 
     void setEdgeIndicesBuffer(const MeshType& mesh) // override

--- a/vclib/render/include/vclib/bgfx/drawable/mesh/mesh_render_buffers.h
+++ b/vclib/render/include/vclib/bgfx/drawable/mesh/mesh_render_buffers.h
@@ -67,7 +67,7 @@ class MeshRenderBuffers : public MeshRenderData<MeshRenderBuffers<Mesh>>
     bool                mVertexQuadBufferGenerated = false;
 
     IndexBuffer mTriangleIndexBuffer;
-    IndexBuffer mTriangleNormalBuffer;
+    VertexBuffer mTriangleNormalBuffer;
     VertexBuffer mTriangleColorBuffer;
 
     Lines mEdgeLines;
@@ -232,7 +232,7 @@ public:
                 chunk.startIndex * 3, chunk.indexCount * 3);
         }
 
-        mTriangleNormalBuffer.bind(VCL_MRB_PRIMITIVE_NORMAL_BUFFER);
+        mTriangleNormalBuffer.bindCompute(VCL_MRB_PRIMITIVE_NORMAL_BUFFER);
 
         mTriangleColorBuffer.bindCompute(VCL_MRB_PRIMITIVE_COLOR_BUFFER);
     }
@@ -513,7 +513,12 @@ private:
         Base::fillTriangleNormals(mesh, buffer);
 
         mTriangleNormalBuffer.create(
-            buffer, nt * 3, PrimitiveType::FLOAT, releaseFn);
+            buffer,
+            nt,
+            bgfx::Attrib::Normal,
+            3,
+            PrimitiveType::FLOAT,
+            releaseFn);
     }
 
     void setTriangleColorsBuffer(const MeshType& mesh) // override

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/points_instance/cs_points_instance.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/points_instance/cs_points_instance.sc
@@ -33,6 +33,9 @@ BUFFER_RO(normals,   vec4, VCL_MRB_VERTEX_NORMAL_STREAM);   // normals (3 floats
 BUFFER_RO(positions, vec4, 0); // coordinates (3 floats)
 BUFFER_RO(normals,   vec4, 1);   // normals (3 floats)
 
+DECLARE_FETCH_VEC3(fetchPosition, positions);
+DECLARE_FETCH_VEC3(fetchNormal, normals);
+
 BUFFER_WO(vOut, vec4, 4); // output vertices
 // 2 vec4 per vertex:
 // - 3 floats for position + 1 float (padding)
@@ -43,18 +46,9 @@ NUM_THREADS(1, 1, 1) // 1 'thread' per point
 void main()
 {
     uint pointId = gl_WorkGroupID.x;
-    uint idx30 = pointId * 3;
-    uint idx31 = idx30+1;
-    uint idx32 = idx30+2;
 
-    vec3 p = vec3(
-        positions[idx30/4][idx30%4],
-        positions[idx31/4][idx31%4],
-        positions[idx32/4][idx32%4]);
-    vec3 n = vec3(
-        normals[idx30/4][idx30%4],
-        normals[idx31/4][idx31%4],
-        normals[idx32/4][idx32%4]);
+    vec3 p = fetchPosition(pointId);
+    vec3 n = fetchNormal(pointId);
 
     // Generate quad vertices
     UNROLL

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_face.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_face.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   false
-#define SURF_SHADING_SMOOTH false
-#define SURF_SHADING_FLAT   true
+#define SURF_SHADING_NONE   0
+#define SURF_SHADING_SMOOTH 0
+#define SURF_SHADING_FLAT   1
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   true
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   1
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_face.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_face.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   0
-#define SURF_SHADING_SMOOTH 0
-#define SURF_SHADING_FLAT   1
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   0
+#define SURF_SHADING_FLAT 1
 #define SURF_COLOR_FACE   1
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_mesh.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_mesh.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   false
-#define SURF_SHADING_SMOOTH false
-#define SURF_SHADING_FLAT   true
+#define SURF_SHADING_NONE   0
+#define SURF_SHADING_SMOOTH 0
+#define SURF_SHADING_FLAT   1
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   true
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   1
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_mesh.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_mesh.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   0
-#define SURF_SHADING_SMOOTH 0
-#define SURF_SHADING_FLAT   1
-
-#define SURF_COLOR_VERTEX 0
+#define SURF_SHADING_FLAT 1
 #define SURF_COLOR_MESH   1
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_user.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_user.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   false
-#define SURF_SHADING_SMOOTH false
-#define SURF_SHADING_FLAT   true
+#define SURF_SHADING_NONE   0
+#define SURF_SHADING_SMOOTH 0
+#define SURF_SHADING_FLAT   1
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   true
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   1
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_user.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_user.sc
@@ -20,15 +20,8 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   0
-#define SURF_SHADING_SMOOTH 0
-#define SURF_SHADING_FLAT   1
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   0
+#define SURF_SHADING_FLAT 1
 #define SURF_COLOR_USER   1
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    0
+
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_vertex.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_vertex.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   false
-#define SURF_SHADING_SMOOTH false
-#define SURF_SHADING_FLAT   true
+#define SURF_SHADING_NONE   0
+#define SURF_SHADING_SMOOTH 0
+#define SURF_SHADING_FLAT   1
 
-#define SURF_COLOR_VERTEX true
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 1
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_vertex.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_color_vertex.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   0
-#define SURF_SHADING_SMOOTH 0
-#define SURF_SHADING_FLAT   1
-
+#define SURF_SHADING_FLAT 1
 #define SURF_COLOR_VERTEX 1
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_tex_vertex.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_tex_vertex.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   false
-#define SURF_SHADING_SMOOTH false
-#define SURF_SHADING_FLAT   true
+#define SURF_SHADING_NONE   0
+#define SURF_SHADING_SMOOTH 0
+#define SURF_SHADING_FLAT   1
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   true
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   1
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_tex_vertex.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_tex_vertex.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   0
-#define SURF_SHADING_SMOOTH 0
-#define SURF_SHADING_FLAT   1
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   0
+#define SURF_SHADING_FLAT 1
 #define SURF_TEX_VERTEX   1
-#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_tex_wedge.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_tex_wedge.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   0
-#define SURF_SHADING_SMOOTH 0
-#define SURF_SHADING_FLAT   1
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   0
+#define SURF_SHADING_FLAT 1
 #define SURF_TEX_WEDGE    1
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_tex_wedge.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_flat_tex_wedge.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   false
-#define SURF_SHADING_SMOOTH false
-#define SURF_SHADING_FLAT   true
+#define SURF_SHADING_NONE   0
+#define SURF_SHADING_SMOOTH 0
+#define SURF_SHADING_FLAT   1
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    true
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    1
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_face.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_face.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   true
-#define SURF_SHADING_SMOOTH false
-#define SURF_SHADING_FLAT   false
+#define SURF_SHADING_NONE   1
+#define SURF_SHADING_SMOOTH 0
+#define SURF_SHADING_FLAT   0
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   true
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   1
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_face.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_face.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   1
-#define SURF_SHADING_SMOOTH 0
-#define SURF_SHADING_FLAT   0
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   0
+#define SURF_SHADING_NONE 1
 #define SURF_COLOR_FACE   1
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_mesh.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_mesh.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   1
-#define SURF_SHADING_SMOOTH 0
-#define SURF_SHADING_FLAT   0
-
-#define SURF_COLOR_VERTEX 0
+#define SURF_SHADING_NONE 1
 #define SURF_COLOR_MESH   1
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_mesh.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_mesh.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   true
-#define SURF_SHADING_SMOOTH false
-#define SURF_SHADING_FLAT   false
+#define SURF_SHADING_NONE   1
+#define SURF_SHADING_SMOOTH 0
+#define SURF_SHADING_FLAT   0
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   true
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   1
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_user.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_user.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   1
-#define SURF_SHADING_SMOOTH 0
-#define SURF_SHADING_FLAT   0
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   0
+#define SURF_SHADING_NONE 1
 #define SURF_COLOR_USER   1
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_user.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_user.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   true
-#define SURF_SHADING_SMOOTH false
-#define SURF_SHADING_FLAT   false
+#define SURF_SHADING_NONE   1
+#define SURF_SHADING_SMOOTH 0
+#define SURF_SHADING_FLAT   0
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   true
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   1
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_vertex.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_vertex.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   true
-#define SURF_SHADING_SMOOTH false
-#define SURF_SHADING_FLAT   false
+#define SURF_SHADING_NONE   1
+#define SURF_SHADING_SMOOTH 0
+#define SURF_SHADING_FLAT   0
 
-#define SURF_COLOR_VERTEX true
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 1
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_vertex.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_color_vertex.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   1
-#define SURF_SHADING_SMOOTH 0
-#define SURF_SHADING_FLAT   0
-
+#define SURF_SHADING_NONE 1
 #define SURF_COLOR_VERTEX 1
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_tex_vertex.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_tex_vertex.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   1
-#define SURF_SHADING_SMOOTH 0
-#define SURF_SHADING_FLAT   0
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   0
+#define SURF_SHADING_NONE 1
 #define SURF_TEX_VERTEX   1
-#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_tex_vertex.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_tex_vertex.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   true
-#define SURF_SHADING_SMOOTH false
-#define SURF_SHADING_FLAT   false
+#define SURF_SHADING_NONE   1
+#define SURF_SHADING_SMOOTH 0
+#define SURF_SHADING_FLAT   0
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   true
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   1
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_tex_wedge.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_tex_wedge.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   1
-#define SURF_SHADING_SMOOTH 0
-#define SURF_SHADING_FLAT   0
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   0
+#define SURF_SHADING_NONE 1
 #define SURF_TEX_WEDGE    1
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_tex_wedge.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_none_tex_wedge.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   true
-#define SURF_SHADING_SMOOTH false
-#define SURF_SHADING_FLAT   false
+#define SURF_SHADING_NONE   1
+#define SURF_SHADING_SMOOTH 0
+#define SURF_SHADING_FLAT   0
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    true
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    1
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_face.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_face.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   0
 #define SURF_SHADING_SMOOTH 1
-#define SURF_SHADING_FLAT   0
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   1
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    0
+#define SURF_COLOR_FACE     1
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_face.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_face.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   false
-#define SURF_SHADING_SMOOTH true
-#define SURF_SHADING_FLAT   false
+#define SURF_SHADING_NONE   0
+#define SURF_SHADING_SMOOTH 1
+#define SURF_SHADING_FLAT   0
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   true
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   1
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_mesh.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_mesh.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   0
 #define SURF_SHADING_SMOOTH 1
-#define SURF_SHADING_FLAT   0
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   1
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    0
+#define SURF_COLOR_MESH     1
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_mesh.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_mesh.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   false
-#define SURF_SHADING_SMOOTH true
-#define SURF_SHADING_FLAT   false
+#define SURF_SHADING_NONE   0
+#define SURF_SHADING_SMOOTH 1
+#define SURF_SHADING_FLAT   0
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   true
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   1
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_user.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_user.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   0
 #define SURF_SHADING_SMOOTH 1
-#define SURF_SHADING_FLAT   0
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   1
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    0
+#define SURF_COLOR_USER     1
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_user.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_user.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   false
-#define SURF_SHADING_SMOOTH true
-#define SURF_SHADING_FLAT   false
+#define SURF_SHADING_NONE   0
+#define SURF_SHADING_SMOOTH 1
+#define SURF_SHADING_FLAT   0
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   true
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   1
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_vertex.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_vertex.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   false
-#define SURF_SHADING_SMOOTH true
-#define SURF_SHADING_FLAT   false
+#define SURF_SHADING_NONE   0
+#define SURF_SHADING_SMOOTH 1
+#define SURF_SHADING_FLAT   0
 
-#define SURF_COLOR_VERTEX true
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 1
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_vertex.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_color_vertex.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   0
 #define SURF_SHADING_SMOOTH 1
-#define SURF_SHADING_FLAT   0
-
-#define SURF_COLOR_VERTEX 1
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    0
+#define SURF_COLOR_VERTEX   1
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_tex_vertex.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_tex_vertex.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   false
-#define SURF_SHADING_SMOOTH true
-#define SURF_SHADING_FLAT   false
+#define SURF_SHADING_NONE   0
+#define SURF_SHADING_SMOOTH 1
+#define SURF_SHADING_FLAT   0
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   true
-#define SURF_TEX_WEDGE    false
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   1
+#define SURF_TEX_WEDGE    0
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_tex_vertex.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_tex_vertex.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   0
 #define SURF_SHADING_SMOOTH 1
-#define SURF_SHADING_FLAT   0
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   1
-#define SURF_TEX_WEDGE    0
+#define SURF_TEX_VERTEX     1
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_tex_wedge.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_tex_wedge.sc
@@ -20,15 +20,15 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   false
-#define SURF_SHADING_SMOOTH true
-#define SURF_SHADING_FLAT   false
+#define SURF_SHADING_NONE   0
+#define SURF_SHADING_SMOOTH 1
+#define SURF_SHADING_FLAT   0
 
-#define SURF_COLOR_VERTEX false
-#define SURF_COLOR_MESH   false
-#define SURF_COLOR_FACE   false
-#define SURF_COLOR_USER   false
-#define SURF_TEX_VERTEX   false
-#define SURF_TEX_WEDGE    true
+#define SURF_COLOR_VERTEX 0
+#define SURF_COLOR_MESH   0
+#define SURF_COLOR_FACE   0
+#define SURF_COLOR_USER   0
+#define SURF_TEX_VERTEX   0
+#define SURF_TEX_WEDGE    1
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_tex_wedge.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_smooth_tex_wedge.sc
@@ -20,15 +20,7 @@
  * (https://www.mozilla.org/en-US/MPL/2.0/) for more details.                *
  ****************************************************************************/
 
-#define SURF_SHADING_NONE   0
 #define SURF_SHADING_SMOOTH 1
-#define SURF_SHADING_FLAT   0
-
-#define SURF_COLOR_VERTEX 0
-#define SURF_COLOR_MESH   0
-#define SURF_COLOR_FACE   0
-#define SURF_COLOR_USER   0
-#define SURF_TEX_VERTEX   0
-#define SURF_TEX_WEDGE    1
+#define SURF_TEX_WEDGE      1
 
 #include "surface_uber_in.sh"

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_uber_pbr.sc
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/fs_surface_uber_pbr.sc
@@ -36,14 +36,15 @@ $input v_position, v_normal, v_tangent, v_color, v_texcoord0, v_texcoord1
 TODO: when https://github.com/bkaradzic/bgfx/issues/3629 will be resolved,
 restore next lines with:
 
-BUFFER_RO(primitiveColors, uint, VCL_MRB_PRIMITIVE_COLOR_BUFFER);    // color of each face / edge
-BUFFER_RO(primitiveNormals, float, VCL_MRB_PRIMITIVE_NORMAL_BUFFER); // normal of each face / edge
+BUFFER_RO(primitiveColors, uint, VCL_MRB_PRIMITIVE_COLOR_BUFFER);   // color of each face / edge
+BUFFER_RO(primitiveNormals, vec4, VCL_MRB_PRIMITIVE_NORMAL_BUFFER); // normal of each face / edge
 
 SAMPLERCUBE(s_irradiance, VCL_MRB_CUBEMAP0);
 SAMPLERCUBE(s_specular, VCL_MRB_CUBEMAP1);
 */
 BUFFER_RO(primitiveColors, uint, 13);    // color of each face / edge
-BUFFER_RO(primitiveNormals, float, 14); // normal of each face / edge
+BUFFER_RO(primitiveNormals, vec4, 14); // normal of each face / edge
+DECLARE_FETCH_VEC3(fetchPrimitiveNormal, primitiveNormals);
 
 SAMPLERCUBE(s_irradiance, 10);
 SAMPLERCUBE(s_specular, 11);

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/surface_uber_in.sh
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/surface_uber_in.sh
@@ -36,11 +36,11 @@ BUFFER_RO(primitiveColors, uint, VCL_MRB_PRIMITIVE_COLOR_BUFFER);   // color of 
 BUFFER_RO(primitiveNormals, vec4, VCL_MRB_PRIMITIVE_NORMAL_BUFFER); // normal of each face / edge
 */
 
-#if SURF_COLOR_FACE
+#ifdef SURF_COLOR_FACE
 BUFFER_RO(primitiveColors, uint, 13);    // color of each face / edge
 #endif
 
-#if SURF_SHADING_FLAT
+#ifdef SURF_SHADING_FLAT
 BUFFER_RO(primitiveNormals, vec4, 14); // normal of each face / edge
 DECLARE_FETCH_VEC3(fetchPrimitiveNormal, primitiveNormals);
 #endif
@@ -57,14 +57,14 @@ void main()
 
     vec3 normal = normalize(v_normal);
 
-#if SURF_SHADING_FLAT
+#ifdef SURF_SHADING_FLAT
     // if flat shading, compute normal of face
     normal = fetchPrimitiveNormal(primitiveID);
     normal = normalize(mul(u_normalMatrix, normal));
 #endif
 
 
-#if !SURF_SHADING_NONE
+#ifndef SURF_SHADING_NONE
     // if flat or smooth shading, compute light
     light = computeLight(u_lightDir, u_lightColor, normal);
 
@@ -82,22 +82,22 @@ void main()
     /***** compute color ******/
     color = uintABGRToVec4Color(floatBitsToUint(u_userSurfaceColorFloat));
 
-#if SURF_COLOR_VERTEX
+#ifdef SURF_COLOR_VERTEX
     color = v_color;
 #endif
-#if SURF_COLOR_MESH
+#ifdef SURF_COLOR_MESH
     color = u_meshColor;
 #endif
-#if SURF_COLOR_FACE
+#ifdef SURF_COLOR_FACE
     color = uintABGRToVec4Color(primitiveColors[primitiveID]);
 #endif
-#if SURF_TEX_VERTEX
+#ifdef SURF_TEX_VERTEX
     if (isBaseColorTextureAvailable())
         color = baseColorTex(v_texcoord0);
     else
         color = vec4(0.0, 0.0, 0.0, 1.0);
 #endif
-# if SURF_TEX_WEDGE
+#ifdef SURF_TEX_WEDGE
     if (isBaseColorTextureAvailable())
         color = baseColorTex(v_texcoord1);
     else

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/surface_uber_in.sh
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/surface_uber_in.sh
@@ -35,8 +35,14 @@ restore next lines with:
 BUFFER_RO(primitiveColors, uint, VCL_MRB_PRIMITIVE_COLOR_BUFFER);    // color of each face / edge
 BUFFER_RO(primitiveNormals, float, VCL_MRB_PRIMITIVE_NORMAL_BUFFER); // normal of each face / edge
 */
+
+#if SURF_COLOR_FACE
 BUFFER_RO(primitiveColors, uint, 13);    // color of each face / edge
+#endif
+
+#if SURF_SHADING_FLAT
 BUFFER_RO(primitiveNormals, float, 14); // normal of each face / edge
+#endif
 
 void main()
 {
@@ -50,54 +56,55 @@ void main()
 
     vec3 normal = normalize(v_normal);
 
+#if SURF_SHADING_FLAT
     // if flat shading, compute normal of face
-    if (SURF_SHADING_FLAT) {
-        normal = vec3(
-            primitiveNormals[primitiveID * 3],
-            primitiveNormals[primitiveID * 3 + 1],
-            primitiveNormals[primitiveID * 3 + 2]);
-        normal = normalize(mul(u_normalMatrix, normal));
-    }
+    normal = vec3(
+        primitiveNormals[primitiveID * 3],
+        primitiveNormals[primitiveID * 3 + 1],
+        primitiveNormals[primitiveID * 3 + 2]);
+    normal = normalize(mul(u_normalMatrix, normal));
+#endif
 
+
+#if !SURF_SHADING_NONE
     // if flat or smooth shading, compute light
-    if (!SURF_SHADING_NONE) {
-        light = computeLight(u_lightDir, u_lightColor, normal);
+    light = computeLight(u_lightDir, u_lightColor, normal);
 
-        // all computations are in view (camera) space
-        // => the camera eye is at (0, 0, 0)
-        // also, u_lightDir is provided in view space
-        specular = computeSpecular(
-            v_position,
-            vec3(0.0, 0.0, 0.0),
-            u_lightDir,
-            u_lightColor,
-            normal);
-    }
+    // all computations are in view (camera) space
+    // => the camera eye is at (0, 0, 0)
+    // also, u_lightDir is provided in view space
+    specular = computeSpecular(
+        v_position,
+        vec3(0.0, 0.0, 0.0),
+        u_lightDir,
+        u_lightColor,
+        normal);
+#endif
 
     /***** compute color ******/
     color = uintABGRToVec4Color(floatBitsToUint(u_userSurfaceColorFloat));
 
-    if (SURF_COLOR_VERTEX) {
-        color = v_color;
-    }
-    if (SURF_COLOR_MESH) {
-        color = u_meshColor;
-    }
-    if (SURF_COLOR_FACE) {
-        color = uintABGRToVec4Color(primitiveColors[primitiveID]);
-    }
-    if (SURF_TEX_VERTEX) {
-        if (isBaseColorTextureAvailable())
-            color = baseColorTex(v_texcoord0);
-        else
-            color = vec4(0.0, 0.0, 0.0, 1.0);
-    }
-    if (SURF_TEX_WEDGE) {
-        if (isBaseColorTextureAvailable())
-            color = baseColorTex(v_texcoord1);
-        else
-            color = vec4(0.0, 0.0, 0.0, 1.0);
-    }
+#if SURF_COLOR_VERTEX
+    color = v_color;
+#endif
+#if SURF_COLOR_MESH
+    color = u_meshColor;
+#endif
+#if SURF_COLOR_FACE
+    color = uintABGRToVec4Color(primitiveColors[primitiveID]);
+#endif
+#if SURF_TEX_VERTEX
+    if (isBaseColorTextureAvailable())
+        color = baseColorTex(v_texcoord0);
+    else
+        color = vec4(0.0, 0.0, 0.0, 1.0);
+#endif
+# if SURF_TEX_WEDGE
+    if (isBaseColorTextureAvailable())
+        color = baseColorTex(v_texcoord1);
+    else
+        color = vec4(0.0, 0.0, 0.0, 1.0);
+#endif
 
     gl_FragColor = light * color + vec4(specular, 0);
 }

--- a/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/surface_uber_in.sh
+++ b/vclib/render/shaders/vclib/bgfx/drawable/drawable_mesh/surface/surface_uber_in.sh
@@ -32,8 +32,8 @@ $input v_position, v_normal, v_tangent, v_color, v_texcoord0, v_texcoord1
 TODO: when https://github.com/bkaradzic/bgfx/issues/3629 will be resolved,
 restore next lines with:
 
-BUFFER_RO(primitiveColors, uint, VCL_MRB_PRIMITIVE_COLOR_BUFFER);    // color of each face / edge
-BUFFER_RO(primitiveNormals, float, VCL_MRB_PRIMITIVE_NORMAL_BUFFER); // normal of each face / edge
+BUFFER_RO(primitiveColors, uint, VCL_MRB_PRIMITIVE_COLOR_BUFFER);   // color of each face / edge
+BUFFER_RO(primitiveNormals, vec4, VCL_MRB_PRIMITIVE_NORMAL_BUFFER); // normal of each face / edge
 */
 
 #if SURF_COLOR_FACE
@@ -41,7 +41,8 @@ BUFFER_RO(primitiveColors, uint, 13);    // color of each face / edge
 #endif
 
 #if SURF_SHADING_FLAT
-BUFFER_RO(primitiveNormals, float, 14); // normal of each face / edge
+BUFFER_RO(primitiveNormals, vec4, 14); // normal of each face / edge
+DECLARE_FETCH_VEC3(fetchPrimitiveNormal, primitiveNormals);
 #endif
 
 void main()
@@ -58,10 +59,7 @@ void main()
 
 #if SURF_SHADING_FLAT
     // if flat shading, compute normal of face
-    normal = vec3(
-        primitiveNormals[primitiveID * 3],
-        primitiveNormals[primitiveID * 3 + 1],
-        primitiveNormals[primitiveID * 3 + 2]);
+    normal = fetchPrimitiveNormal(primitiveID);
     normal = normalize(mul(u_normalMatrix, normal));
 #endif
 

--- a/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_in.sh
+++ b/vclib/render/shaders/vclib/bgfx/primitives/points/vs_points_in.sh
@@ -26,9 +26,11 @@ $output v_normal, v_texcoord1, v_color
 #include <vclib/bgfx/primitives/uniforms/points_uniforms.sh>
 
 BUFFER_RO(pointsBuffer, vec4, 0); // 3D point positions
+DECLARE_FETCH_VEC3(fetchPosition, pointsBuffer);
 
 #if POINTS_SHADING_PER_VERTEX
 BUFFER_RO(normalsBuffer, vec4, 1); // 3D normals
+DECLARE_FETCH_VEC3(fetchNormal, normalsBuffer);
 #endif
 
 #if POINTS_COLOR_PER_VERTEX
@@ -37,22 +39,12 @@ BUFFER_RO(pointColors, uint, 2); // colors
 
 void main()
 {
-    // Calculate which point and which vertex of the quad we're processing
+    // Calculate which point and which vertex of the quad we are processing
     // Each point generates 6 vertices (2 triangles)
     uint pointIndex = gl_VertexID / 6u;
     uint localVertex = gl_VertexID % 6u;
 
-    uint idx30 = pointIndex * 3u;
-    uint idx31 = idx30 + 1u;
-    uint idx32 = idx30 + 2u;
-
-    // Unroll a continuous stream of floats from a vec4 compute buffer.
-    // Each point's position takes 3 floats, but the SSBO is accessed as vec4 elements.
-    // idx/4u computes the vec4 index, and idx%4u selects the correct scalar component.
-    vec3 centerPos = vec3(
-        pointsBuffer[idx30/4u][idx30%4u],
-        pointsBuffer[idx31/4u][idx31%4u],
-        pointsBuffer[idx32/4u][idx32%4u]);
+    vec3 centerPos = fetchPosition(pointIndex);
 
     const vec2 offsets[6] = {
         vec2(-1.0, -1.0), vec2(-1.0,  1.0), vec2( 1.0, -1.0),
@@ -76,11 +68,7 @@ void main()
 
     // Normal calculation
 #if POINTS_SHADING_PER_VERTEX
-    // Same vec4 unrolling logic as point positions
-    v_normal = vec3(
-        normalsBuffer[idx30/4u][idx30%4u],
-        normalsBuffer[idx31/4u][idx31%4u],
-        normalsBuffer[idx32/4u][idx32%4u]);
+    v_normal = fetchNormal(pointIndex);
     v_normal = normalize(mul(u_normalMatrix, v_normal));
 #else
     v_normal = vec3(0.0, 0.0, 1.0);

--- a/vclib/render/shaders/vclib/bgfx/shaders_common.sh
+++ b/vclib/render/shaders/vclib/bgfx/shaders_common.sh
@@ -37,6 +37,37 @@
 #define vcl_FrontFacing (!gl_FrontFacing)
 
 /**
+ * @brief Auxiliary macro to declare a function that fetches a vec3 from a vec4
+ * buffer.
+ *
+ * Buffers cannot be passed as arguments to functions, so we need to declare a
+ * function for each buffer that is declared of vec4 but actually contains vec3
+ * data.
+ * This macro makes easier to declare such functions.
+ *
+ * @param[in] funcName: The name of the function to be generated.
+ * @param[in] bufferName: The name of the vec4 buffer from which the vec3 will
+ * be fetched.
+ *
+ * @code
+ * BUFFER_RO(myBuffer, vec4, 0); // buffer of vec4, read only on stage 0
+ * DECLARE_FETCH_VEC3(fetchMyBuffer, myBuffer) // declare the function
+ * //...
+ * vec3 pos = fetchMyBuffer(10); // fetch the 10-th vec3 from myBuffer
+ * @endcode
+ */
+#define DECLARE_FETCH_VEC3(funcName, bufferName) \
+    vec3 funcName(uint index) { \
+        uint idx30 = index * 3u; \
+        uint idx31 = idx30 + 1u; \
+        uint idx32 = idx30 + 2u; \
+        return vec3( \
+            bufferName[idx30 / 4u][idx30 % 4u], \
+            bufferName[idx31 / 4u][idx31 % 4u], \
+            bufferName[idx32 / 4u][idx32 % 4u]); \
+    }
+
+/**
  * @brief Convert an uint color in ABGR format to a vec4 float color.
  * @param[in] color: The input color.
  * @return The output color.


### PR DESCRIPTION
This PR refactors the mesh rendering pipeline by changing how triangle normal and color buffers are handled within `MeshRenderBuffers`. It also simplifies and cleans up the mesh surface shaders by leveraging `#ifdef` preprocessor directives instead of complex macros, and introduces a new shader utility for extracting `vec3` data from `vec4` buffers.